### PR TITLE
Externalize runtime config from server.js

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
+# Optional custom config path (defaults to config.local.json, then config.json)
+# COMMAND_CENTER_CONFIG=./config.local.json
+
 # Google Calendar iCal URLs
 # Get from: Google Calendar → Settings → [Calendar name] → Secret address in iCal format
 # Leave empty to disable the Calendar tab
+# You can use either CALENDAR_URLS (comma-separated) or the legacy CAL_1 / CAL_2 vars.
+CALENDAR_URLS=
 CAL_1=https://calendar.google.com/calendar/ical/you@gmail.com/private-xxxxx/basic.ics
 CAL_2=https://calendar.google.com/calendar/ical/group.calendar.google.com/private-xxxxx/basic.ics

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 .env
+config.local.json
 
 node_modules/
 .env
+config.local.json
 puppeteer-browsers/

--- a/README.md
+++ b/README.md
@@ -71,62 +71,67 @@ npm install
 
 ### 3. Configure
 
-Copy the example env file and fill in your values:
+Copy the example env file and config file:
 
 ```bash
 cp .env.example .env
+cp config.example.json config.local.json
 ```
 
-Edit `.env`:
+Edit `.env` for calendar URLs:
 
 ```env
-# Google Calendar iCal URLs (optional — leave empty to skip)
+# Optional custom config path
+# COMMAND_CENTER_CONFIG=./config.local.json
+
+# Calendar URLs (optional)
+CALENDAR_URLS=
 CAL_1=https://calendar.google.com/calendar/ical/you@gmail.com/private-xxxxx/basic.ics
 CAL_2=https://calendar.google.com/calendar/ical/group.calendar.google.com/private-xxxxx/basic.ics
 ```
 
+Edit `config.local.json` for your machine:
+
+```json
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 4500
+  },
+  "github": {
+    "trackedRepos": [
+      "YourOrg/repo-one",
+      "YourOrg/repo-two",
+      "yourusername/personal-repo"
+    ],
+    "orgs": [
+      {
+        "owner": "YourOrg",
+        "repoLimit": 200
+      }
+    ]
+  },
+  "obsidian": {
+    "vaultDir": "/path/to/your/obsidian/vault",
+    "dailyDir": "/path/to/your/obsidian/vault/03 - Periodic/01 - Daily",
+    "decisionsDir": "/path/to/your/obsidian/vault/08 - Projects/DamageLabs/Decisions",
+    "tasksDir": "/path/to/your/tasks/folder",
+    "taskFiles": [
+      { "file": "Tasks.md", "label": "General", "color": "amber" },
+      { "file": "Work Tasks.md", "label": "Work", "color": "blue" }
+    ]
+  },
+  "standup": {
+    "dir": "${HOME}/Code/brain/standups/daily"
+  }
+}
+```
+
+`config.local.json` is ignored by git and is the recommended place for personal paths and repo lists.
+
 **Get your iCal URLs:** Google Calendar → Settings → [Calendar name] → _Secret address in iCal format_
 
-### 4. Edit `server.js` for your setup
-
-Open `server.js` and update these constants near the top:
-
-#### GitHub repos to track (issues + PRs)
-
-```js
-const ACTIVE_REPOS = [
-  'YourOrg/repo-one',
-  'YourOrg/repo-two',
-  'yourusername/personal-repo',
-];
-```
-
-These repos get full issue detail in Urgent/Active/Backlog. All repos from your org(s) appear in the Repos tab.
-
-To change which orgs are listed in Repos, update the fetch calls in `fetchGitHub()`:
-
-```js
-const allRepos = gh('repo list YourOrg --json name,isArchived,pushedAt --limit 200')
-  .map(r => ({ name: `YourOrg/${r.name}`, archived: r.isArchived }));
-```
-
-#### Obsidian vault (optional)
-
-```js
-const VAULT_DIR = '/path/to/your/obsidian/vault';
-const DAILY_DIR = `${VAULT_DIR}/your-daily-notes-folder`;
-const DECISIONS_DIR = `${VAULT_DIR}/your-decisions-folder`;
-```
-
-#### Obsidian tasks (optional)
-
-```js
-const TASKS_DIR = '/path/to/your/tasks/folder';
-const TASK_FILES = [
-  { file: 'Tasks.md', label: 'General', color: 'amber' },
-  { file: 'Work Tasks.md', label: 'Work', color: 'blue' },
-];
-```
+#### Obsidian task format
 
 Task files should use standard Obsidian checkbox format:
 
@@ -135,27 +140,15 @@ Task files should use standard Obsidian checkbox format:
 - [x] Completed task ✅ 2026-04-01
 ```
 
-#### Daily standups (optional)
+#### Daily standups
 
-```js
-const STANDUP_DIR = '/path/to/your/standups/daily';
-```
-
-Expects files named `YYYY-MM-DD.md` with `### Repo/Name` sections.
+Standup files should be named `YYYY-MM-DD.md` and use `### Repo/Name` sections.
 
 #### Issue priority labels
 
-```js
-// Customize which labels map to which priority bucket
-function issuePriority(labels) {
-  const names = labels.map(l => l.name.toLowerCase());
-  if (names.some(n => n.includes('bug') || n.includes('urgent'))) return 'urgent';
-  if (names.some(n => n.includes('enhancement') || n.includes('feature'))) return 'active';
-  return 'deferred';
-}
-```
+Issue bucketing is still controlled in `server.js` via `issuePriority(labels)`.
 
-### 5. Run
+### 4. Run
 
 ```bash
 # Development (direct)
@@ -169,7 +162,7 @@ pm2 startup  # auto-start on reboot
 
 Runs on **http://localhost:4500**.
 
-### 6. Local HTTPS with Caddy (optional but recommended)
+### 5. Local HTTPS with Caddy (optional but recommended)
 
 Install [Caddy](https://caddyserver.com) and [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html), then:
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,47 @@
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 4500
+  },
+  "github": {
+    "trackedRepos": [
+      "YourOrg/repo-one",
+      "YourOrg/repo-two",
+      "yourusername/personal-repo"
+    ],
+    "orgs": [
+      {
+        "owner": "YourOrg",
+        "repoLimit": 200
+      },
+      {
+        "owner": "yourusername",
+        "repoLimit": 100,
+        "includeRepos": [
+          "personal-repo"
+        ]
+      }
+    ]
+  },
+  "obsidian": {
+    "vaultDir": "/path/to/your/obsidian/vault",
+    "dailyDir": "/path/to/your/obsidian/vault/03 - Periodic/01 - Daily",
+    "decisionsDir": "/path/to/your/obsidian/vault/08 - Projects/DamageLabs/Decisions",
+    "tasksDir": "/path/to/your/tasks/folder",
+    "taskFiles": [
+      {
+        "file": "Tasks.md",
+        "label": "General",
+        "color": "amber"
+      },
+      {
+        "file": "Work Tasks.md",
+        "label": "Work",
+        "color": "blue"
+      }
+    ]
+  },
+  "standup": {
+    "dir": "${HOME}/Code/brain/standups/daily"
+  }
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const HOME_DIR = process.env.HOME || process.env.USERPROFILE || '';
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeDeep(base, override) {
+  if (Array.isArray(override)) return [...override];
+  if (!isPlainObject(override)) return override;
+
+  const result = isPlainObject(base) ? { ...base } : {};
+  for (const [key, value] of Object.entries(override)) {
+    if (Array.isArray(value)) {
+      result[key] = [...value];
+    } else if (isPlainObject(value)) {
+      result[key] = mergeDeep(result[key], value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function uniqStrings(values) {
+  return [...new Set((values || []).filter(Boolean).map(v => String(v).trim()).filter(Boolean))];
+}
+
+function expandHome(value) {
+  if (typeof value !== 'string') return value;
+  if (!value) return value;
+  let expanded = value.replace(/\$\{HOME\}/g, HOME_DIR);
+  if (expanded === '~') return HOME_DIR;
+  if (expanded.startsWith('~/')) return path.join(HOME_DIR, expanded.slice(2));
+  return expanded;
+}
+
+function resolveConfigPath() {
+  const candidates = [];
+  if (process.env.COMMAND_CENTER_CONFIG) {
+    candidates.push(path.resolve(ROOT_DIR, process.env.COMMAND_CENTER_CONFIG));
+  }
+  candidates.push(
+    path.join(ROOT_DIR, 'config.local.json'),
+    path.join(ROOT_DIR, 'config.json'),
+    path.join(ROOT_DIR, 'config.example.json')
+  );
+
+  for (const filePath of candidates) {
+    if (fs.existsSync(filePath)) return filePath;
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function readConfigFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function parseCalendarUrls() {
+  const urls = [];
+
+  if (process.env.CALENDAR_URLS) {
+    urls.push(...process.env.CALENDAR_URLS.split(','));
+  }
+
+  urls.push(process.env.CAL_1, process.env.CAL_2);
+
+  return uniqStrings(urls);
+}
+
+function normalizeConfig(config) {
+  const defaults = {
+    server: {
+      host: '127.0.0.1',
+      port: 4500,
+    },
+    github: {
+      trackedRepos: [],
+      orgs: [],
+    },
+    obsidian: {
+      vaultDir: '',
+      dailyDir: '',
+      decisionsDir: '',
+      tasksDir: '',
+      taskFiles: [],
+    },
+    standup: {
+      dir: '${HOME}/Code/brain/standups/daily',
+    },
+    calendar: {
+      icalUrls: [],
+    },
+  };
+
+  const merged = mergeDeep(defaults, config || {});
+
+  const normalized = {
+    server: {
+      host: expandHome(merged.server?.host || defaults.server.host),
+      port: Number(merged.server?.port) || defaults.server.port,
+    },
+    github: {
+      trackedRepos: uniqStrings(merged.github?.trackedRepos),
+      orgs: (merged.github?.orgs || [])
+        .filter(org => org && typeof org.owner === 'string' && org.owner.trim())
+        .map(org => ({
+          owner: org.owner.trim(),
+          repoLimit: Number(org.repoLimit) || 200,
+          includeRepos: uniqStrings(org.includeRepos),
+          excludeRepos: uniqStrings(org.excludeRepos),
+        })),
+    },
+    obsidian: {
+      vaultDir: expandHome(merged.obsidian?.vaultDir || ''),
+      dailyDir: expandHome(merged.obsidian?.dailyDir || ''),
+      decisionsDir: expandHome(merged.obsidian?.decisionsDir || ''),
+      tasksDir: expandHome(merged.obsidian?.tasksDir || ''),
+      taskFiles: (merged.obsidian?.taskFiles || [])
+        .filter(file => file && typeof file.file === 'string' && file.file.trim())
+        .map(file => ({
+          file: file.file.trim(),
+          label: typeof file.label === 'string' && file.label.trim() ? file.label.trim() : file.file.trim(),
+          color: typeof file.color === 'string' && file.color.trim() ? file.color.trim() : 'amber',
+        })),
+    },
+    standup: {
+      dir: expandHome(merged.standup?.dir || defaults.standup.dir),
+    },
+    calendar: {
+      icalUrls: uniqStrings([...(merged.calendar?.icalUrls || []), ...parseCalendarUrls()]),
+    },
+  };
+
+  if (!normalized.obsidian.dailyDir && normalized.obsidian.vaultDir) {
+    normalized.obsidian.dailyDir = path.join(normalized.obsidian.vaultDir, '03 - Periodic', '01 - Daily');
+  }
+
+  if (!normalized.obsidian.decisionsDir && normalized.obsidian.vaultDir) {
+    normalized.obsidian.decisionsDir = path.join(normalized.obsidian.vaultDir, '08 - Projects', 'DamageLabs', 'Decisions');
+  }
+
+  return normalized;
+}
+
+function validateConfig(config, configPath) {
+  const warnings = [];
+  if (!config.github.trackedRepos.length) {
+    warnings.push('GitHub PR tracking is disabled because github.trackedRepos is empty.');
+  }
+  if (!config.github.orgs.length) {
+    warnings.push('GitHub repo and issue discovery is disabled because github.orgs is empty.');
+  }
+  if (!config.obsidian.tasksDir || !config.obsidian.taskFiles.length) {
+    warnings.push('Obsidian tasks are disabled because obsidian.tasksDir or obsidian.taskFiles is missing.');
+  }
+  if (!config.obsidian.dailyDir) {
+    warnings.push('Daily notes are disabled because obsidian.dailyDir is not configured.');
+  }
+  if (!config.obsidian.decisionsDir) {
+    warnings.push('Decision notes are disabled because obsidian.decisionsDir is not configured.');
+  }
+  if (!config.standup.dir) {
+    warnings.push('Standups are disabled because standup.dir is not configured.');
+  }
+  if (!config.calendar.icalUrls.length) {
+    warnings.push('Calendar is disabled because no iCal URLs were provided in CALENDAR_URLS, CAL_1, or CAL_2.');
+  }
+
+  if (configPath.endsWith('config.example.json')) {
+    warnings.unshift('Using config.example.json. Copy it to config.local.json or config.json and customize it for your machine.');
+  }
+
+  return warnings;
+}
+
+function loadConfig() {
+  const configPath = resolveConfigPath();
+  const rawConfig = readConfigFile(configPath);
+  const config = normalizeConfig(rawConfig);
+  const warnings = validateConfig(config, configPath);
+  return { config, configPath, warnings };
+}
+
+module.exports = {
+  loadConfig,
+};

--- a/server.js
+++ b/server.js
@@ -8,40 +8,29 @@ const path = require('path');
 const cron = require('node-cron');
 const ical = require('node-ical');
 const fs = require('fs');
+const { loadConfig } = require('./lib/config');
 
 const app = express();
-const PORT = 4500;
+const { config: runtimeConfig, configPath, warnings: configWarnings } = loadConfig();
+const PORT = runtimeConfig.server.port;
+const HOST = runtimeConfig.server.host;
 
 // ── Config ────────────────────────────────────────────────────────────────────
-const ACTIVE_REPOS = [
-  'DamageLabs/uas-log',
-  'DamageLabs/armory-core',
-  'DamageLabs/damagelabs.io',
-  'DamageLabs/paper_trail_manager',
-  'DamageLabs/clahub',
-  'DamageLabs/whiskey-canon',
-  'DamageLabs/sports-card-tracker',
-  'DamageLabs/brain',
-  'DamageLabs/command-center',
-  'fusion94/fusion94.org',
-  'fusion94/clawd',
-];
+const ACTIVE_REPOS = runtimeConfig.github.trackedRepos;
+const GITHUB_ORGS = runtimeConfig.github.orgs;
 
-const TASKS_DIR = '/Users/guntharp/Documents/guntharp-personal/02 - Action/01 - Tasks';
-const VAULT_DIR = '/Users/guntharp/Documents/guntharp-personal';
-const DAILY_DIR = `${VAULT_DIR}/03 - Periodic/01 - Daily`;
-const DECISIONS_DIR = `${VAULT_DIR}/08 - Projects/DamageLabs/Decisions`;
-const STANDUP_DIR = `${process.env.HOME}/Code/brain/standups/daily`;
-const TASK_FILES = [
-  { file: '02 - General Tasks.md', label: 'General', color: 'amber' },
-  { file: '03 - CA Tasks.md',      label: 'California', color: 'blue' },
-  { file: '04 - TX Tasks.md',      label: 'Texas', color: 'green' },
-];
+const DAILY_DIR = runtimeConfig.obsidian.dailyDir;
+const DECISIONS_DIR = runtimeConfig.obsidian.decisionsDir;
+const TASKS_DIR = runtimeConfig.obsidian.tasksDir;
+const TASK_FILES = runtimeConfig.obsidian.taskFiles;
+const STANDUP_DIR = runtimeConfig.standup.dir;
 
-const CALENDAR_URLS = [
-  process.env.CAL_1,
-  process.env.CAL_2,
-].filter(Boolean);
+const CALENDAR_URLS = runtimeConfig.calendar.icalUrls;
+
+console.log(`[config] loaded ${path.relative(__dirname, configPath) || configPath}`);
+for (const warning of configWarnings) {
+  console.warn(`[config] ${warning}`);
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function issuePriority(labels) {
@@ -53,6 +42,33 @@ function issuePriority(labels) {
 
 function gh(cmd) {
   return JSON.parse(execSync(`gh ${cmd}`, { encoding: 'utf8', maxBuffer: 4 * 1024 * 1024 }));
+}
+
+function configuredRepos() {
+  const deduped = new Map();
+
+  for (const org of GITHUB_ORGS) {
+    try {
+      let repos = gh(`repo list ${org.owner} --json name,isArchived,pushedAt --limit ${org.repoLimit}`);
+      if (org.includeRepos.length) {
+        repos = repos.filter(repo => org.includeRepos.includes(repo.name));
+      }
+      if (org.excludeRepos.length) {
+        repos = repos.filter(repo => !org.excludeRepos.includes(repo.name));
+      }
+
+      for (const repo of repos) {
+        deduped.set(`${org.owner}/${repo.name}`, {
+          name: `${org.owner}/${repo.name}`,
+          archived: repo.isArchived,
+        });
+      }
+    } catch (error) {
+      console.warn(`[github] skipping org ${org.owner}: ${error.message}`);
+    }
+  }
+
+  return [...deduped.values()];
 }
 
 // ── Cache ─────────────────────────────────────────────────────────────────────
@@ -98,6 +114,13 @@ function parseTaskRecord(raw, label, color, section, completed = false) {
 function fetchPRs() {
   console.log('[prs] fetching open PRs...');
   try {
+    if (!ACTIVE_REPOS.length) {
+      cache.prs = [];
+      cache.prsUpdatedAt = Date.now();
+      console.log('[prs] skipped, no github.trackedRepos configured');
+      return;
+    }
+
     const allPRs = [];
     for (const repo of ACTIVE_REPOS) {
       try {
@@ -216,7 +239,7 @@ function parseStandupSections(content) {
 function fetchStandup() {
   console.log('[standup] reading latest standup...');
   try {
-    if (!fs.existsSync(STANDUP_DIR)) {
+    if (!STANDUP_DIR || !fs.existsSync(STANDUP_DIR)) {
       cache.standup = null;
       return;
     }
@@ -253,26 +276,31 @@ function fetchNotes() {
     const now = new Date();
     const result = { dailyNote: null, decisions: [], updatedAt: Date.now() };
 
+    if (!DAILY_DIR && !DECISIONS_DIR) {
+      cache.notes = result;
+      console.log('[notes] skipped, no obsidian daily/decisions paths configured');
+      return;
+    }
+
     // Find today's or most recent daily note
     const months = ['01-January','02-February','03-March','04-April','05-May','06-June',
       '07-July','08-August','09-September','10-October','11-November','12-December'];
     const year = now.getFullYear();
     const month = months[now.getMonth()];
     const pad = n => String(n).padStart(2,'0');
-    const todayFile = `${year}-${pad(now.getMonth()+1)}-${pad(now.getDate())}.md`;
-    const monthDir = `${DAILY_DIR}/${year}/${month}`;
-
     // Try today, then walk back up to 7 days
     let noteContent = null, noteDate = null;
-    for (let i = 0; i < 7; i++) {
-      const d = new Date(now - i * 86400000);
-      const m = months[d.getMonth()];
-      const fname = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}.md`;
-      const fpath = `${DAILY_DIR}/${d.getFullYear()}/${m}/${fname}`;
-      if (fs.existsSync(fpath)) {
-        noteContent = fs.readFileSync(fpath, 'utf8');
-        noteDate = fname.replace('.md','');
-        break;
+    if (DAILY_DIR) {
+      for (let i = 0; i < 7; i++) {
+        const d = new Date(now - i * 86400000);
+        const m = months[d.getMonth()];
+        const fname = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}.md`;
+        const fpath = `${DAILY_DIR}/${d.getFullYear()}/${m}/${fname}`;
+        if (fs.existsSync(fpath)) {
+          noteContent = fs.readFileSync(fpath, 'utf8');
+          noteDate = fname.replace('.md','');
+          break;
+        }
       }
     }
 
@@ -297,7 +325,7 @@ function fetchNotes() {
     }
 
     // Recent decisions
-    if (fs.existsSync(DECISIONS_DIR)) {
+    if (DECISIONS_DIR && fs.existsSync(DECISIONS_DIR)) {
       const files = fs.readdirSync(DECISIONS_DIR)
         .filter(f => f.endsWith('.md'))
         .sort().reverse().slice(0, 5);
@@ -332,6 +360,15 @@ function fetchTasks() {
   try {
     const result = [];
     const completed = [];
+
+    if (!TASKS_DIR || !TASK_FILES.length) {
+      cache.tasks = result;
+      cache.completedTasks = completed;
+      cache.tasksUpdatedAt = Date.now();
+      console.log('[tasks] skipped, no tasks config found');
+      return;
+    }
+
     for (const { file, label, color } of TASK_FILES) {
       const fullPath = `${TASKS_DIR}/${file}`;
       if (!fs.existsSync(fullPath)) continue;
@@ -372,18 +409,18 @@ function fetchTasks() {
 function fetchGitHub() {
   console.log('[github] fetching issues...');
   try {
-    // Fetch all DamageLabs + fusion94 repos dynamically
-    const damagelabsRepos = gh('repo list DamageLabs --json name,isArchived,pushedAt --limit 200')
-      .map(r => ({ name: `DamageLabs/${r.name}`, archived: r.isArchived }));
-    const fusion94Repos = gh('repo list fusion94 --json name,isArchived,pushedAt --limit 100')
-      .filter(r => ['fusion94.org','clawd','dotfiles','homeassistant'].includes(r.name))
-      .map(r => ({ name: `fusion94/${r.name}`, archived: r.isArchived }));
-    const allRepos = [...damagelabsRepos, ...fusion94Repos];
+    if (!GITHUB_ORGS.length) {
+      cache.issues = [];
+      cache.repoStats = [];
+      cache.issuesUpdatedAt = Date.now();
+      console.log('[github] skipped, no github.orgs configured');
+      return;
+    }
+
+    const allRepos = configuredRepos();
 
     const allIssues = [];
     const repoStats = [];
-
-    // Fetch issues only for ACTIVE_REPOS (prioritized); collect stats for all
     for (const { name: repo, archived } of allRepos) {
       try {
         const issues = gh(`issue list --repo ${repo} --state open --json number,title,labels,assignees,createdAt,url,milestone --limit 100`);
@@ -672,6 +709,6 @@ app.post('/api/refresh', async (req, res) => {
   res.json({ ok: true });
 });
 
-app.listen(PORT, '127.0.0.1', () => {
-  console.log(`command-center running at http://127.0.0.1:${PORT}`);
+app.listen(PORT, HOST, () => {
+  console.log(`command-center running at http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary
Externalizes command-center runtime configuration from `server.js` into a dedicated config layer, while keeping Tony's current local setup working through an ignored `config.local.json`.

Closes #46.

## What Changed
- Added `lib/config.js` to load runtime config from `config.local.json`, `config.json`, or `config.example.json`
- Added `config.example.json` with documented structure for server, GitHub, Obsidian, standup, and calendar settings
- Updated `server.js` to consume config-driven repos, paths, host/port, and calendar URLs instead of inline Tony-specific constants
- Added startup warnings for missing config so disabled sources are explicit
- Updated `.env.example`, `.gitignore`, and `README.md` to document the new local config flow

## Commits
- `8095770` feat(config): load command-center runtime config from files
- `f3b26e6` docs(config): document local config setup
