### PR TITLE
Improve dashboard source states and Home layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -153,7 +153,20 @@
     }
     .view-subtitle {
       font-size: 0.8rem; color: var(--text-muted);
+      display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap;
     }
+    .source-pill {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      padding: 0.12rem 0.5rem; border-radius: 999px;
+      border: 1px solid transparent;
+      font-size: 0.68rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .source-pill.fresh { background: rgba(34,197,94,0.12); color: var(--green-400); border-color: rgba(34,197,94,0.18); }
+    .source-pill.refreshing { background: rgba(96,165,250,0.12); color: var(--blue-400); border-color: rgba(96,165,250,0.18); }
+    .source-pill.loading { background: rgba(148,163,184,0.12); color: var(--text-muted); border-color: rgba(148,163,184,0.18); }
+    .source-pill.stale { background: rgba(245,158,11,0.12); color: var(--amber-400); border-color: rgba(245,158,11,0.18); }
+    .source-pill.failed { background: rgba(248,113,113,0.12); color: var(--red-400); border-color: rgba(248,113,113,0.18); }
     .view-body {
       flex: 1; overflow-y: auto; padding: 1.25rem 2rem;
     }
@@ -1522,11 +1535,61 @@
 
   // ── Helpers ────────────────────────────────────────────────────────────────
   function timeAgo(iso) {
+    if (!iso) return 'unknown';
     const s = Math.floor((Date.now() - new Date(iso)) / 1000);
+    if (!Number.isFinite(s)) return 'unknown';
     if (s < 60) return `${s}s ago`;
     if (s < 3600) return `${Math.floor(s/60)}m ago`;
     if (s < 86400) return `${Math.floor(s/3600)}h ago`;
     return `${Math.floor(s/86400)}d ago`;
+  }
+
+  function truncateText(value, max = 96) {
+    const text = String(value || '').trim();
+    if (!text || text.length <= max) return text;
+    return `${text.slice(0, max - 1)}…`;
+  }
+
+  function sourceStatusLabel(status) {
+    if (status === 'refreshing') return 'Refreshing';
+    if (status === 'stale') return 'Stale';
+    if (status === 'failed') return 'Failed';
+    if (status === 'loading') return 'Loading';
+    return 'Fresh';
+  }
+
+  function sourceStatusTone(status) {
+    if (status === 'refreshing') return 'refreshing';
+    if (status === 'stale') return 'stale';
+    if (status === 'failed') return 'failed';
+    if (status === 'loading') return 'loading';
+    return 'fresh';
+  }
+
+  function formatSourceSubtitle(summary, source) {
+    if (!source) return escHtml(summary);
+
+    let detail = summary || source.label;
+    if (source.status === 'loading') {
+      detail = `Loading ${source.label.toLowerCase()}…`;
+    } else if (source.status === 'refreshing') {
+      detail = `${summary} · Refreshing now`;
+    } else if (source.status === 'stale') {
+      detail = `${summary} · Last good update ${timeAgo(source.updatedAt)}`;
+    } else if (source.status === 'failed') {
+      detail = truncateText(source.error || `${source.label} is unavailable`);
+    } else if (source.updatedAt) {
+      detail = `${summary} · Updated ${timeAgo(source.updatedAt)}`;
+    }
+
+    return `<span class="source-pill ${sourceStatusTone(source.status)}">${escHtml(sourceStatusLabel(source.status))}</span><span>${escHtml(detail)}</span>`;
+  }
+
+  function setViewSubtitle(id, summary, source) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.innerHTML = formatSourceSubtitle(summary, source);
+    el.dataset.state = source?.status || 'unknown';
   }
 
   function labelClass(name) {
@@ -1792,7 +1855,12 @@
   async function fetchIssues() {
     const res = await fetch('/api/issues');
     const data = await res.json();
-    if (!data.ok) throw new Error(data.error);
+    if (!data.ok) {
+      setViewSubtitle('sub-urgent', 'Issues unavailable', data.source);
+      setViewSubtitle('sub-active', 'Issues unavailable', data.source);
+      setViewSubtitle('sub-backlog', 'Issues unavailable', data.source);
+      throw new Error(data.error);
+    }
 
     document.getElementById('badge-urgent').textContent = data.urgent.length;
     document.getElementById('badge-active').textContent = data.active.length;
@@ -1801,9 +1869,9 @@
     checkNotifs('active', data.active.length);
     checkNotifs('backlog', data.deferred.length);
 
-    document.getElementById('sub-urgent').textContent = `${data.urgent.length} issues · Updated ${timeAgo(data.updatedAt)}`;
-    document.getElementById('sub-active').textContent = `${data.active.length} issues · Updated ${timeAgo(data.updatedAt)}`;
-    document.getElementById('sub-backlog').textContent = `${data.deferred.length} issues · Updated ${timeAgo(data.updatedAt)}`;
+    setViewSubtitle('sub-urgent', `${data.urgent.length} issues`, data.source);
+    setViewSubtitle('sub-active', `${data.active.length} issues`, data.source);
+    setViewSubtitle('sub-backlog', `${data.deferred.length} issues`, data.source);
 
     window._lastIssuesData = data;
     renderIssueColumns(data);
@@ -1994,13 +2062,15 @@
   async function fetchPRs() {
     const res = await fetch('/api/prs');
     const data = await res.json();
-    if (!data.ok) throw new Error(data.error);
+    if (!data.ok) {
+      setViewSubtitle('sub-prs', 'PRs unavailable', data.source);
+      throw new Error(data.error);
+    }
     const prs = data.prs;
     window._lastPRsData = prs;
     document.getElementById('badge-prs').textContent = prs.length;
     checkNotifs('prs', prs.length);
-    document.getElementById('sub-prs').textContent =
-      `${prs.length} open · ${prs.filter(p=>p.isDraft).length} drafts · Updated ${timeAgo(data.updatedAt)}`;
+    setViewSubtitle('sub-prs', `${prs.length} open · ${prs.filter(p=>p.isDraft).length} drafts`, data.source);
     renderPRColumns(prs);
     renderHomePinned();
   }
@@ -2044,12 +2114,14 @@
   async function fetchNotes() {
     const res = await fetch('/api/notes');
     const data = await res.json();
-    if (!data.ok) throw new Error(data.error);
+    if (!data.ok) {
+      setViewSubtitle('sub-notes', 'Notes unavailable', data.source);
+      throw new Error(data.error);
+    }
 
     const total = (data.dailyNote ? 1 : 0) + data.decisions.length;
     document.getElementById('badge-notes').textContent = total;
-    document.getElementById('sub-notes').textContent =
-      `${data.dailyNote ? data.dailyNote.date : 'No recent daily note'} · ${data.decisions.length} decisions · Updated ${timeAgo(data.updatedAt)}`;
+    setViewSubtitle('sub-notes', `${data.dailyNote ? data.dailyNote.date : 'No recent daily note'} · ${data.decisions.length} decisions`, data.source);
 
     // Option A: Notes tab
     const el = document.getElementById('col-notes');
@@ -2119,13 +2191,16 @@
     try {
       const res = await fetch('/api/infra');
       const data = await res.json();
-      if (!data.ok) throw new Error(data.error);
+      if (!data.ok) {
+        setViewSubtitle('sub-infra', 'Infra unavailable', data.source || { status: 'failed', label: 'Infra', error: data.error });
+        throw new Error(data.error);
+      }
       const procs = data.processes;
       const online = procs.filter(p => p.status === 'online').length;
       const down = procs.filter(p => p.status !== 'online').length;
       const restarts = procs.reduce((s,p) => s + (p.restarts||0), 0);
       document.getElementById('badge-infra').textContent = online + '/' + procs.length;
-      document.getElementById('sub-infra').textContent = `${online} online · ${down} down · ${restarts} restarts · Updated ${timeAgo(data.updatedAt)}`;
+      setViewSubtitle('sub-infra', `${online} online · ${down} down · ${restarts} restarts`, data.source);
       el.className = '';
       el.style.cssText = 'display:flex;flex-direction:column;gap:0';
       el.innerHTML = `
@@ -2163,7 +2238,7 @@
     } catch (e) {
       const message = (e && e.message) ? e.message : 'Infra unavailable';
       document.getElementById('badge-infra').textContent = '—';
-      document.getElementById('sub-infra').textContent = 'Infra unavailable';
+      setViewSubtitle('sub-infra', 'Infra unavailable', { status: 'failed', label: 'Infra', error: message });
       el.className = '';
       el.style.cssText = 'display:flex;flex-direction:column;gap:1rem';
       el.innerHTML = `
@@ -2239,7 +2314,11 @@
   async function fetchTasks() {
     const res = await fetch('/api/tasks');
     const data = await res.json();
-    if (!data.ok) throw new Error(data.error);
+    if (!data.ok) {
+      setViewSubtitle('sub-tasks', 'Tasks unavailable', data.source);
+      setViewSubtitle('sub-done', 'Completed tasks unavailable', data.source);
+      throw new Error(data.error);
+    }
     const tasks = data.tasks;
     const completedTasks = data.completedTasks || [];
     window._lastTasksData = tasks;
@@ -2247,8 +2326,8 @@
     document.getElementById('badge-done').textContent = completedTasks.length;
     checkNotifs('tasks', tasks.length);
     checkNotifs('done', completedTasks.length);
-    document.getElementById('sub-tasks').textContent = `${tasks.length} open tasks · Updated ${timeAgo(data.updatedAt)}`;
-    document.getElementById('sub-done').textContent = `${completedTasks.length} completed tasks · Updated ${timeAgo(data.updatedAt)}`;
+    setViewSubtitle('sub-tasks', `${tasks.length} open tasks`, data.source);
+    setViewSubtitle('sub-done', `${completedTasks.length} completed tasks`, data.source);
     renderTaskColumns(tasks);
     renderCompletedTaskColumns(completedTasks);
     reapplyCurrentFilter();
@@ -2308,11 +2387,14 @@
   async function fetchCalendar() {
     const res = await fetch('/api/calendar');
     const data = await res.json();
-    if (!data.ok) throw new Error(data.error);
+    if (!data.ok) {
+      setViewSubtitle('sub-calendar', 'Calendar unavailable', data.source);
+      throw new Error(data.error);
+    }
     const events = data.events;
     window._lastEventsData = events;
     document.getElementById('badge-cal').textContent = events.length;
-    document.getElementById('sub-calendar').textContent = `${events.length} upcoming events · Updated ${timeAgo(data.updatedAt)}`;
+    setViewSubtitle('sub-calendar', `${events.length} upcoming events`, data.source);
     renderCalendarColumns(events);
     _homeData.events = events; tryRenderHome();
   }
@@ -2336,11 +2418,14 @@
   async function fetchRepos() {
     const res = await fetch('/api/repos');
     const data = await res.json();
-    if (!data.ok) throw new Error(data.error);
+    if (!data.ok) {
+      setViewSubtitle('sub-repos', 'Repos unavailable', data.source);
+      throw new Error(data.error);
+    }
     const repos = data.repos.sort((a,b) => b.openIssues - a.openIssues);
     window._lastReposData = repos;
     document.getElementById('badge-repos').textContent = repos.length;
-    document.getElementById('sub-repos').textContent = `${repos.length} repos · ${repos.reduce((s,r) => s + r.openIssues, 0)} open · Updated ${timeAgo(data.updatedAt)}`;
+    setViewSubtitle('sub-repos', `${repos.length} repos · ${repos.reduce((s,r) => s + r.openIssues, 0)} open`, data.source);
     renderRepoColumns(repos);
     renderHomePinned();
   }
@@ -2350,8 +2435,9 @@
     const body = document.getElementById('analytics-body');
     try {
       const res = await fetch('/api/analytics');
-      if (!res.ok) throw new Error('loading');
       const data = await res.json();
+      setViewSubtitle('sub-analytics', `Last 30 days — ${(data.sites || []).length} properties`, data.source);
+      if (!res.ok) throw new Error(data.error || data.source?.error || 'loading');
       if (!data.totals) throw new Error('no data');
 
       const { totals, sites, updatedAt, range } = data;
@@ -2361,8 +2447,7 @@
         ? `${Math.floor(avgDuration/60)}m ${avgDuration%60}s`
         : `${avgDuration}s`;
 
-      document.getElementById('sub-analytics').textContent =
-        `Last 30 days — ${sites.length} properties · Updated ${timeAgo(updatedAt)}`;
+      setViewSubtitle('sub-analytics', `Last 30 days — ${sites.length} properties`, data.source);
 
       body.innerHTML = `
         <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:1rem;margin-bottom:1.5rem;">

--- a/public/index.html
+++ b/public/index.html
@@ -888,6 +888,26 @@
       text-align: center; padding: 3rem 1rem;
       color: var(--text-muted); font-size: 0.875rem;
     }
+    .state-card {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: 14px; padding: 1rem 1.1rem;
+      display: flex; flex-direction: column; gap: 0.45rem;
+    }
+    .state-card.compact { padding: 0.9rem 1rem; min-height: 0; }
+    .state-card.empty { border-style: dashed; }
+    .state-card.error { border-color: rgba(248,113,113,0.22); background: rgba(248,113,113,0.05); }
+    .state-eyebrow {
+      font-size: 0.7rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--text-muted);
+    }
+    .state-card.error .state-eyebrow { color: var(--red-300); }
+    .state-title {
+      font-size: 0.95rem; font-weight: 650; color: var(--text-primary);
+    }
+    .state-detail {
+      font-size: 0.82rem; line-height: 1.55; color: var(--text-secondary);
+      white-space: pre-wrap;
+    }
     .skeleton {
       background: var(--bg-card); border-radius: 10px;
       height: 76px; animation: shimmer 1.4s infinite;
@@ -1592,6 +1612,29 @@
     el.dataset.state = source?.status || 'unknown';
   }
 
+  function normalizeErrorText(value) {
+    return truncateText(String(value || '').replace(/\s+/g, ' ').trim(), 160);
+  }
+
+  function renderStateCard({ tone = 'empty', eyebrow = 'Status', title, detail = '', compact = false } = {}) {
+    return `
+      <div class="state-card ${tone}${compact ? ' compact' : ''}">
+        <div class="state-eyebrow">${escHtml(eyebrow)}</div>
+        <div class="state-title">${escHtml(title)}</div>
+        ${detail ? `<div class="state-detail">${escHtml(detail)}</div>` : ''}
+      </div>
+    `;
+  }
+
+  function renderEmptyState(title, detail, compact = false) {
+    return renderStateCard({ tone: 'empty', eyebrow: 'Empty', title, detail, compact });
+  }
+
+  function renderUnavailableState(title, detail, error = '', compact = false) {
+    const message = error ? `${detail} ${normalizeErrorText(error)}`.trim() : detail;
+    return renderStateCard({ tone: 'error', eyebrow: 'Unavailable', title, detail: message, compact });
+  }
+
   function labelClass(name) {
     const n = name.toLowerCase();
     if (n.includes('bug')) return 'bug';
@@ -1859,7 +1902,12 @@
       setViewSubtitle('sub-urgent', 'Issues unavailable', data.source);
       setViewSubtitle('sub-active', 'Issues unavailable', data.source);
       setViewSubtitle('sub-backlog', 'Issues unavailable', data.source);
-      throw new Error(data.error);
+      const message = data.error || data.source?.error || 'Issue data could not be loaded.';
+      document.getElementById('col-urgent').innerHTML = renderUnavailableState('Issues unavailable', 'Urgent issues could not be loaded.', message, true);
+      document.getElementById('col-active').innerHTML = renderUnavailableState('Issues unavailable', 'Active issues could not be loaded.', message, true);
+      document.getElementById('col-backlog').innerHTML = renderUnavailableState('Issues unavailable', 'Backlog issues could not be loaded.', message, true);
+      document.getElementById('home-issues').innerHTML = renderUnavailableState('Issues unavailable', 'The Home view could not load recent issues.', message, true);
+      throw new Error(message);
     }
 
     document.getElementById('badge-urgent').textContent = data.urgent.length;
@@ -1882,7 +1930,7 @@
     const renderCol = (id, arr) => {
       const el = document.getElementById(id);
       el.className = 'issues-grid';
-      if (!arr.length) { el.innerHTML = '<div class="empty">Nothing here 🎉</div>'; return; }
+      if (!arr.length) { el.innerHTML = renderEmptyState('Nothing here', 'No items currently match this view.', true); return; }
       const pinned = arr.filter(i => isPinned('issue', `${i.repoFull}#${i.number}`));
       const unpinned = arr.filter(i => !isPinned('issue', `${i.repoFull}#${i.number}`));
       let html = '';
@@ -1969,7 +2017,7 @@
             <div class="home-item-meta"><span class="home-item-accent">${dateStr} · ${timeStr}</span><span>${e.calendar}</span></div>
           </div>`;
         }).join('')
-      : '<div class="empty" style="padding:1rem">No upcoming events</div>';
+      : renderEmptyState('No upcoming events', 'Nothing is scheduled in the current window.', true);
 
     // Recent issues (pinned first)
     const issuesTitle = document.getElementById('home-issues-title');
@@ -1983,7 +2031,7 @@
             <div class="home-item-meta"><span class="home-item-accent">${i.repo}</span><span>#${i.number}</span><span>${timeAgo(i.createdAt)}</span></div>
           </a>`;
         }).join('')
-      : '<div class="empty" style="padding:1rem">No urgent issues 🎉</div>';
+      : renderEmptyState('No urgent issues', 'The urgent queue is clear right now.', true);
 
     // Open tasks
     document.getElementById('home-tasks').innerHTML = openTasks.length
@@ -1992,7 +2040,7 @@
             <div class="home-item-title">${escHtml(t.title)}</div>
             <div class="home-item-meta"><span class="home-item-accent">${t.source}</span>${t.section ? `<span>${escHtml(t.section)}</span>` : ''}${t.due ? `<span style="color:var(--red-400)">📅 ${t.due}</span>` : ''}</div>
           </div>`).join('')
-      : '<div class="empty" style="padding:1rem">All done! 🎉</div>';
+      : renderEmptyState('All done', 'There are no open tasks to show here.', true);
   }
 
   const SERVICE_DOMAINS = {
@@ -2046,7 +2094,7 @@
   function renderPRColumns(prs) {
     const el = document.getElementById('col-prs');
     el.className = 'pr-grid';
-    if (!prs.length) { el.innerHTML = '<div class="empty">No open PRs 🎉</div>'; return; }
+    if (!prs.length) { el.innerHTML = renderEmptyState('No open PRs', 'There are no pull requests waiting right now.', true); return; }
     const pinned = prs.filter(p => isPinned('pr', `${p.repoFull}#${p.number}`));
     const unpinned = prs.filter(p => !isPinned('pr', `${p.repoFull}#${p.number}`));
     let html = '';
@@ -2064,7 +2112,9 @@
     const data = await res.json();
     if (!data.ok) {
       setViewSubtitle('sub-prs', 'PRs unavailable', data.source);
-      throw new Error(data.error);
+      const message = data.error || data.source?.error || 'Pull requests could not be loaded.';
+      document.getElementById('col-prs').innerHTML = renderUnavailableState('PRs unavailable', 'Pull requests could not be loaded for this view.', message, true);
+      throw new Error(message);
     }
     const prs = data.prs;
     window._lastPRsData = prs;
@@ -2078,7 +2128,29 @@
   async function fetchStandup() {
     const res = await fetch('/api/standup');
     const data = await res.json();
-    if (!data.ok || !data.standup) return;
+    if (!data.ok) {
+      const message = data.error || 'Standup data could not be loaded.';
+      const homeEl = document.getElementById('home-standup');
+      if (homeEl) {
+        homeEl.innerHTML = renderUnavailableState('Standup unavailable', 'The latest standup could not be loaded for the Home view.', message);
+      }
+      const notesStandup = document.getElementById('notes-standup');
+      if (notesStandup) {
+        notesStandup.innerHTML = renderUnavailableState('Standup unavailable', 'The latest standup could not be loaded for the Notes view.', message);
+      }
+      return;
+    }
+    if (!data.standup) {
+      const homeEl = document.getElementById('home-standup');
+      if (homeEl) {
+        homeEl.innerHTML = renderEmptyState('No standup yet', 'A recent standup has not been loaded yet.');
+      }
+      const notesStandup = document.getElementById('notes-standup');
+      if (notesStandup) {
+        notesStandup.innerHTML = renderEmptyState('No standup yet', 'A recent standup has not been loaded yet.');
+      }
+      return;
+    }
     const s = data.standup;
 
     // Home standup card
@@ -2116,7 +2188,10 @@
     const data = await res.json();
     if (!data.ok) {
       setViewSubtitle('sub-notes', 'Notes unavailable', data.source);
-      throw new Error(data.error);
+      const message = data.error || data.source?.error || 'Notes could not be loaded.';
+      document.getElementById('col-notes').innerHTML = renderUnavailableState('Notes unavailable', 'Recent notes could not be loaded from the configured paths.', message);
+      document.getElementById('home-daily-note').innerHTML = renderUnavailableState('Daily note unavailable', 'The Home view could not load the latest daily note.', message);
+      throw new Error(message);
     }
 
     const total = (data.dailyNote ? 1 : 0) + data.decisions.length;
@@ -2144,7 +2219,7 @@
         </div>
       `;
     } else {
-      html += `<div class="empty">No recent daily notes found</div>`;
+      html += renderEmptyState('No recent daily note', 'No recent daily note was found in the configured Obsidian paths.');
     }
 
     // Decisions section
@@ -2181,7 +2256,7 @@
           </div>
         `;
       } else {
-        homeNote.innerHTML = '';
+        homeNote.innerHTML = renderEmptyState('No recent daily note', 'No recent daily note was found in the configured Obsidian paths.');
       }
     }
   }
@@ -2241,14 +2316,11 @@
       setViewSubtitle('sub-infra', 'Infra unavailable', { status: 'failed', label: 'Infra', error: message });
       el.className = '';
       el.style.cssText = 'display:flex;flex-direction:column;gap:1rem';
-      el.innerHTML = `
-        <div class="card" style="padding:1.25rem;display:flex;flex-direction:column;gap:0.6rem;">
-          <div style="font-size:0.82rem;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-muted);">Infra unavailable</div>
-          <div style="font-size:1rem;font-weight:600;color:var(--text-primary);">Process monitoring could not be loaded.</div>
-          <div style="font-size:0.85rem;color:var(--text-secondary);line-height:1.5;">The rest of command-center is still working, but the Infra source failed. This commonly happens when PM2 is not installed or not available in the runtime environment.</div>
-          <pre style="margin:0;padding:0.85rem 1rem;border:1px solid var(--border);border-radius:12px;background:var(--bg-elev);color:var(--text-muted);font-size:0.78rem;white-space:pre-wrap;word-break:break-word;">${escHtml(message)}</pre>
-        </div>
-      `;
+      el.innerHTML = renderUnavailableState(
+        'Process monitoring could not be loaded',
+        'The rest of command-center is still working, but the Infra source failed. This commonly happens when PM2 is not installed or not available in the runtime environment.',
+        message
+      );
       _homeData.infra = { ok: false, processes: [], updatedAt: null, error: message };
     }
     tryRenderHome();
@@ -2290,7 +2362,7 @@
   function renderTaskColumns(tasks) {
     const el = document.getElementById('col-tasks');
     el.className = 'tasks-grid';
-    if (!tasks.length) { el.innerHTML = '<div class="empty">All done! 🎉</div>'; return; }
+    if (!tasks.length) { el.innerHTML = renderEmptyState('All done', 'There are no open tasks right now.'); return; }
     const pinned = tasks.filter(t => isPinned('task', taskKey(t)));
     const unpinned = tasks.filter(t => !isPinned('task', taskKey(t)));
     let html = '';
@@ -2308,7 +2380,7 @@
     doneEl.className = 'tasks-grid';
     doneEl.innerHTML = completedTasks.length
       ? completedTasks.map(renderCompletedTaskCard).join('')
-      : '<div class="empty">No completed tasks found yet</div>';
+      : renderEmptyState('No completed tasks yet', 'Completed tasks will appear here once they are finished.');
   }
 
   async function fetchTasks() {
@@ -2317,7 +2389,11 @@
     if (!data.ok) {
       setViewSubtitle('sub-tasks', 'Tasks unavailable', data.source);
       setViewSubtitle('sub-done', 'Completed tasks unavailable', data.source);
-      throw new Error(data.error);
+      const message = data.error || data.source?.error || 'Tasks could not be loaded.';
+      document.getElementById('col-tasks').innerHTML = renderUnavailableState('Tasks unavailable', 'Open tasks could not be loaded from Obsidian.', message);
+      document.getElementById('col-tasks-done').innerHTML = renderUnavailableState('Completed tasks unavailable', 'Completed tasks could not be loaded from Obsidian.', message);
+      document.getElementById('home-tasks').innerHTML = renderUnavailableState('Tasks unavailable', 'The Home view could not load open tasks.', message, true);
+      throw new Error(message);
     }
     const tasks = data.tasks;
     const completedTasks = data.completedTasks || [];
@@ -2371,7 +2447,7 @@
     const now = new Date();
     const col = document.getElementById('col-calendar');
     col.className = 'cal-grid';
-    if (!events.length) { col.innerHTML = '<div class="empty">No upcoming events 🎉</div>'; return; }
+    if (!events.length) { col.innerHTML = renderEmptyState('No upcoming events', 'Nothing is scheduled in the next window.'); return; }
     const pinned = events.filter(e => isPinned('event', eventKey(e)));
     const unpinned = events.filter(e => !isPinned('event', eventKey(e)));
     let html = '';
@@ -2389,7 +2465,10 @@
     const data = await res.json();
     if (!data.ok) {
       setViewSubtitle('sub-calendar', 'Calendar unavailable', data.source);
-      throw new Error(data.error);
+      const message = data.error || data.source?.error || 'Calendar events could not be loaded.';
+      document.getElementById('col-calendar').innerHTML = renderUnavailableState('Calendar unavailable', 'Upcoming events could not be loaded for this view.', message);
+      document.getElementById('home-events').innerHTML = renderUnavailableState('Calendar unavailable', 'The Home view could not load upcoming events.', message, true);
+      throw new Error(message);
     }
     const events = data.events;
     window._lastEventsData = events;
@@ -2402,6 +2481,10 @@
   function renderRepoColumns(repos) {
     const el = document.getElementById('col-repos');
     el.className = 'repos-grid';
+    if (!repos.length) {
+      el.innerHTML = renderEmptyState('No repos configured', 'Add tracked repos in command-center config to populate this view.');
+      return;
+    }
     const pinned = repos.filter(r => isPinned('repo', r.repoFull));
     const unpinned = repos.filter(r => !isPinned('repo', r.repoFull));
     let html = '';
@@ -2420,7 +2503,9 @@
     const data = await res.json();
     if (!data.ok) {
       setViewSubtitle('sub-repos', 'Repos unavailable', data.source);
-      throw new Error(data.error);
+      const message = data.error || data.source?.error || 'Repository health could not be loaded.';
+      document.getElementById('col-repos').innerHTML = renderUnavailableState('Repos unavailable', 'Repository health could not be loaded for this view.', message);
+      throw new Error(message);
     }
     const repos = data.repos.sort((a,b) => b.openIssues - a.openIssues);
     window._lastReposData = repos;
@@ -2524,7 +2609,7 @@
           &middot; Refreshes every 15 min
         </div>`;
     } catch(e) {
-      body.innerHTML = `<div style="color:var(--text-muted);padding:2rem;text-align:center;">Analytics unavailable — ${e.message}</div>`;
+      body.innerHTML = renderUnavailableState('Analytics unavailable', 'Analytics data could not be loaded for this view.', e.message);
     }
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -638,6 +638,64 @@
     .home-pinned-item:hover .home-pinned-unpin { opacity: 1; }
     .home-pinned-unpin:hover { background: rgba(239,68,68,0.2); color: var(--red-400); }
     .home-pinned-empty { color: var(--text-muted); font-size: 0.85rem; padding: 0.5rem 0; }
+    .home-toolbar {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;
+    }
+    .home-toolbar-title {
+      font-size: 0.82rem; font-weight: 700; letter-spacing: 0.06em;
+      text-transform: uppercase; color: var(--text-secondary);
+    }
+    .home-toolbar-sub { font-size: 0.82rem; color: var(--text-muted); margin-top: 0.2rem; }
+    .home-toolbar-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+    .home-toolbar-btn, .home-module-btn, .home-hidden-chip {
+      background: var(--bg-card); border: 1px solid var(--border); color: var(--text-secondary);
+      border-radius: 999px; padding: 0.38rem 0.75rem; font-size: 0.76rem;
+      cursor: pointer; transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+    .home-toolbar-btn:hover, .home-module-btn:hover, .home-hidden-chip:hover {
+      border-color: rgba(245,158,11,0.3); color: var(--text-primary);
+    }
+    .home-toolbar-btn:disabled, .home-module-btn:disabled {
+      opacity: 0.45; cursor: not-allowed;
+    }
+    .home-toolbar-btn.active, .home-module-btn.active {
+      border-color: rgba(245,158,11,0.42); color: var(--accent); background: rgba(245,158,11,0.08);
+    }
+    .home-layout {
+      display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1.5rem; align-items: start;
+    }
+    .home-module { min-width: 0; }
+    .home-module-span-3 { grid-column: 1 / -1; }
+    .home-module-header {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 0.75rem; margin-bottom: 0.75rem;
+    }
+    .home-module-header .home-section-title { margin-bottom: 0; }
+    .home-module-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+    .home-module-actions .home-module-btn { padding: 0.3rem 0.55rem; }
+    .home-module.is-collapsed .home-module-body { display: none; }
+    .home-module.is-hidden { display: none; }
+    .home-layout.customize .home-module-actions { opacity: 1; }
+    .home-layout.compact .home-event-item,
+    .home-layout.compact .home-issue-item,
+    .home-layout.compact .home-task-item,
+    .home-layout.compact .home-pinned-item,
+    .home-layout.compact .reminder-card,
+    .home-layout.compact .card,
+    .home-layout.compact .state-card {
+      padding-top: 0.65rem;
+      padding-bottom: 0.65rem;
+    }
+    .home-layout.compact .home-item-title,
+    .home-layout.compact .home-pinned-title { font-size: 0.8rem; }
+    .home-layout.compact .home-item-meta,
+    .home-layout.compact .home-pinned-meta,
+    .home-layout.compact .state-detail { font-size: 0.75rem; }
+    .home-hidden-list {
+      display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem;
+    }
 
     /* ── Reminders ── */
     .reminder-card {
@@ -1109,33 +1167,68 @@
         <div class="reminder-list" id="reminder-list"></div>
       </div>
 
-      <!-- Pinned items -->
-      <div id="home-pinned-section" style="display:none;margin-bottom:1.5rem">
-        <div class="home-section-title" style="margin-bottom:0.75rem">📌 Pinned</div>
-        <div id="home-pinned-items"></div>
-      </div>
-
-      <!-- Next event + recent issues -->
-      <div class="home-grid">
-        <div class="home-section">
-          <div class="home-section-title">Upcoming</div>
-          <div id="home-events"><div class="skeleton" style="height:72px"></div></div>
+      <div class="home-toolbar">
+        <div>
+          <div class="home-toolbar-title">Home layout</div>
+          <div class="home-toolbar-sub" id="home-layout-summary">Prioritize the sections you check most often.</div>
         </div>
-        <div class="home-section">
-          <div class="home-section-title" id="home-issues-title">Recent Issues</div>
-          <div id="home-issues"><div class="skeleton" style="height:72px"></div><div class="skeleton" style="height:72px;margin-top:0.5rem"></div></div>
-        </div>
-        <div class="home-section">
-          <div class="home-section-title">Open Tasks</div>
-          <div id="home-tasks"><div class="skeleton" style="height:72px"></div><div class="skeleton" style="height:72px;margin-top:0.5rem"></div></div>
+        <div class="home-toolbar-actions">
+          <button class="home-toolbar-btn" id="home-compact-btn" onclick="toggleHomeCompact()">Compact mode</button>
+          <button class="home-toolbar-btn" id="home-customize-btn" onclick="toggleHomeCustomize()">Customize</button>
+          <button class="home-toolbar-btn" onclick="resetHomeLayout()">Reset layout</button>
         </div>
       </div>
+      <div class="home-hidden-list" id="home-hidden-list" style="display:none"></div>
 
-      <!-- Daily note card (Option B) -->
-      <div id="home-daily-note"></div>
+      <div class="home-layout" id="home-layout">
+        <section class="home-module home-module-span-3" data-home-section="pinned">
+          <div class="home-module-header">
+            <div class="home-section-title">📌 Pinned</div>
+            <div class="home-module-actions"></div>
+          </div>
+          <div class="home-module-body" id="home-pinned-items"></div>
+        </section>
 
-      <!-- Standup card -->
-      <div id="home-standup" style="margin-top:1.5rem"><div class="skeleton" style="height:200px"></div></div>
+        <section class="home-module" data-home-section="upcoming">
+          <div class="home-module-header">
+            <div class="home-section-title">Upcoming</div>
+            <div class="home-module-actions"></div>
+          </div>
+          <div class="home-module-body" id="home-events"><div class="skeleton" style="height:72px"></div></div>
+        </section>
+
+        <section class="home-module" data-home-section="issues">
+          <div class="home-module-header">
+            <div class="home-section-title" id="home-issues-title">Recent Issues</div>
+            <div class="home-module-actions"></div>
+          </div>
+          <div class="home-module-body" id="home-issues"><div class="skeleton" style="height:72px"></div><div class="skeleton" style="height:72px;margin-top:0.5rem"></div></div>
+        </section>
+
+        <section class="home-module" data-home-section="tasks">
+          <div class="home-module-header">
+            <div class="home-section-title">Open Tasks</div>
+            <div class="home-module-actions"></div>
+          </div>
+          <div class="home-module-body" id="home-tasks"><div class="skeleton" style="height:72px"></div><div class="skeleton" style="height:72px;margin-top:0.5rem"></div></div>
+        </section>
+
+        <section class="home-module home-module-span-3" data-home-section="daily-note">
+          <div class="home-module-header">
+            <div class="home-section-title">Daily Note</div>
+            <div class="home-module-actions"></div>
+          </div>
+          <div class="home-module-body" id="home-daily-note"></div>
+        </section>
+
+        <section class="home-module home-module-span-3" data-home-section="standup">
+          <div class="home-module-header">
+            <div class="home-section-title">Latest Standup</div>
+            <div class="home-module-actions"></div>
+          </div>
+          <div class="home-module-body" id="home-standup"><div class="skeleton" style="height:200px"></div></div>
+        </section>
+      </div>
 
     </div>
   </div>
@@ -1360,6 +1453,186 @@
     applyTheme(saved || preferred);
   })();
 
+  const HOME_LAYOUT_KEY = 'cc-home-layout';
+  const HOME_SECTION_LABELS = {
+    pinned: 'Pinned',
+    upcoming: 'Upcoming',
+    issues: 'Recent Issues',
+    tasks: 'Open Tasks',
+    'daily-note': 'Daily Note',
+    standup: 'Latest Standup',
+  };
+  const DEFAULT_HOME_LAYOUT = {
+    order: ['pinned', 'upcoming', 'issues', 'tasks', 'daily-note', 'standup'],
+    hidden: [],
+    collapsed: [],
+    compact: false,
+  };
+  let homeCustomizeMode = false;
+
+  function availableHomeSections() {
+    return Array.from(document.querySelectorAll('#home-layout [data-home-section]')).map(el => el.dataset.homeSection);
+  }
+
+  function loadHomeLayout() {
+    try {
+      return { ...DEFAULT_HOME_LAYOUT, ...(JSON.parse(localStorage.getItem(HOME_LAYOUT_KEY) || '{}')) };
+    } catch {
+      return { ...DEFAULT_HOME_LAYOUT };
+    }
+  }
+
+  function sanitizeHomeLayout(layout) {
+    const allowed = availableHomeSections();
+    const incomingOrder = Array.isArray(layout.order) ? layout.order : [];
+    const order = [...new Set(incomingOrder.filter(id => allowed.includes(id)).concat(allowed.filter(id => !incomingOrder.includes(id))))];
+    const hidden = [...new Set((Array.isArray(layout.hidden) ? layout.hidden : []).filter(id => allowed.includes(id)))];
+    const collapsed = [...new Set((Array.isArray(layout.collapsed) ? layout.collapsed : []).filter(id => allowed.includes(id)))];
+    return { order, hidden, collapsed, compact: !!layout.compact };
+  }
+
+  let homeLayout = sanitizeHomeLayout(loadHomeLayout());
+
+  function persistHomeLayout() {
+    localStorage.setItem(HOME_LAYOUT_KEY, JSON.stringify(homeLayout));
+  }
+
+  function updateHomeLayoutSummary() {
+    const summary = document.getElementById('home-layout-summary');
+    if (!summary) return;
+    const bits = [];
+    bits.push(homeLayout.compact ? 'Compact mode is on.' : 'Standard density.');
+    if (homeLayout.hidden.length) bits.push(`${homeLayout.hidden.length} hidden section${homeLayout.hidden.length === 1 ? '' : 's'}.`);
+    if (homeCustomizeMode) bits.push('Customize mode is on.');
+    summary.textContent = bits.join(' ');
+  }
+
+  function renderHomeModuleActions(module, index, total) {
+    const actions = module.querySelector('.home-module-actions');
+    if (!actions) return;
+    const sectionId = module.dataset.homeSection;
+    const collapsed = homeLayout.collapsed.includes(sectionId);
+    const controls = [
+      `<button class="home-module-btn${collapsed ? ' active' : ''}" onclick="toggleHomeSectionCollapsed('${sectionId}')" title="${collapsed ? 'Expand' : 'Collapse'} section">${collapsed ? 'Expand' : 'Collapse'}</button>`
+    ];
+    if (homeCustomizeMode) {
+      controls.push(`<button class="home-module-btn" onclick="pinHomeSectionToTop('${sectionId}')" title="Pin section to the top">Top</button>`);
+      controls.push(`<button class="home-module-btn" onclick="moveHomeSection('${sectionId}', -1)" ${index === 0 ? 'disabled' : ''} title="Move section earlier">↑</button>`);
+      controls.push(`<button class="home-module-btn" onclick="moveHomeSection('${sectionId}', 1)" ${index === total - 1 ? 'disabled' : ''} title="Move section later">↓</button>`);
+      controls.push(`<button class="home-module-btn" onclick="toggleHomeSectionHidden('${sectionId}')" title="Hide section">Hide</button>`);
+    }
+    actions.innerHTML = controls.join('');
+  }
+
+  function renderHiddenHomeSections() {
+    const container = document.getElementById('home-hidden-list');
+    if (!container) return;
+    if (!homeLayout.hidden.length) {
+      container.style.display = 'none';
+      container.innerHTML = '';
+      return;
+    }
+    container.style.display = 'flex';
+    container.innerHTML = homeLayout.hidden.map(id => `
+      <button class="home-hidden-chip" onclick="restoreHomeSection('${id}')">Show ${HOME_SECTION_LABELS[id] || id}</button>
+    `).join('');
+  }
+
+  function applyHomeLayout() {
+    const container = document.getElementById('home-layout');
+    if (!container) return;
+    homeLayout = sanitizeHomeLayout(homeLayout);
+    persistHomeLayout();
+
+    const modules = new Map(Array.from(container.querySelectorAll('[data-home-section]')).map(module => [module.dataset.homeSection, module]));
+    homeLayout.order.forEach(id => {
+      const module = modules.get(id);
+      if (module) container.appendChild(module);
+    });
+
+    container.classList.toggle('compact', homeLayout.compact);
+    container.classList.toggle('customize', homeCustomizeMode);
+    document.getElementById('home-compact-btn')?.classList.toggle('active', homeLayout.compact);
+    document.getElementById('home-customize-btn')?.classList.toggle('active', homeCustomizeMode);
+
+    homeLayout.order.forEach((id, index) => {
+      const module = modules.get(id);
+      if (!module) return;
+      const autoHidden = module.dataset.autoHidden === 'true';
+      const hidden = homeLayout.hidden.includes(id) || (autoHidden && !homeCustomizeMode);
+      module.classList.toggle('is-hidden', hidden);
+      module.classList.toggle('is-collapsed', homeLayout.collapsed.includes(id));
+      renderHomeModuleActions(module, index, homeLayout.order.length);
+    });
+
+    renderHiddenHomeSections();
+    updateHomeLayoutSummary();
+  }
+
+  function updateHomeLayoutState(mutator) {
+    const next = JSON.parse(JSON.stringify(homeLayout));
+    mutator(next);
+    homeLayout = sanitizeHomeLayout(next);
+    applyHomeLayout();
+  }
+
+  function toggleHomeCompact() {
+    updateHomeLayoutState(layout => { layout.compact = !layout.compact; });
+  }
+
+  function toggleHomeCustomize() {
+    homeCustomizeMode = !homeCustomizeMode;
+    applyHomeLayout();
+  }
+
+  function resetHomeLayout() {
+    homeLayout = sanitizeHomeLayout({ ...DEFAULT_HOME_LAYOUT });
+    homeCustomizeMode = false;
+    applyHomeLayout();
+  }
+
+  function toggleHomeSectionCollapsed(sectionId) {
+    updateHomeLayoutState(layout => {
+      layout.collapsed = layout.collapsed.includes(sectionId)
+        ? layout.collapsed.filter(id => id !== sectionId)
+        : [...layout.collapsed, sectionId];
+    });
+  }
+
+  function toggleHomeSectionHidden(sectionId) {
+    updateHomeLayoutState(layout => {
+      layout.hidden = layout.hidden.includes(sectionId)
+        ? layout.hidden.filter(id => id !== sectionId)
+        : [...layout.hidden, sectionId];
+    });
+  }
+
+  function restoreHomeSection(sectionId) {
+    updateHomeLayoutState(layout => {
+      layout.hidden = layout.hidden.filter(id => id !== sectionId);
+    });
+  }
+
+  function moveHomeSection(sectionId, delta) {
+    updateHomeLayoutState(layout => {
+      const idx = layout.order.indexOf(sectionId);
+      if (idx === -1) return;
+      const nextIdx = Math.max(0, Math.min(layout.order.length - 1, idx + delta));
+      if (idx === nextIdx) return;
+      const [item] = layout.order.splice(idx, 1);
+      layout.order.splice(nextIdx, 0, item);
+    });
+  }
+
+  function pinHomeSectionToTop(sectionId) {
+    updateHomeLayoutState(layout => {
+      layout.order = [sectionId, ...layout.order.filter(id => id !== sectionId)];
+      layout.hidden = layout.hidden.filter(id => id !== sectionId);
+    });
+  }
+
+  applyHomeLayout();
+
   // ── Filter state ──────────────────────────────────────────────────────────
   let activeFilter = { repo: null, text: '' };
 
@@ -1433,9 +1706,9 @@
   let currentView = 'home';
   function renderHomePinned() {
     const pins = getPinned();
-    const section = document.getElementById('home-pinned-section');
+    const module = document.querySelector('#home-layout [data-home-section="pinned"]');
     const container = document.getElementById('home-pinned-items');
-    if (!section || !container) return;
+    if (!module || !container) return;
 
     const items = [];
 
@@ -1498,8 +1771,12 @@
       });
     });
 
-    section.style.display = items.length ? '' : 'none';
-    if (!items.length) return;
+    module.dataset.autoHidden = items.length ? 'false' : 'true';
+    if (!items.length) {
+      container.innerHTML = renderEmptyState('Nothing pinned yet', 'Pin an issue, PR, task, event, or repo to keep it at the top of Home.', true);
+      applyHomeLayout();
+      return;
+    }
 
     container.innerHTML = items.map((item, idx) => {
       const clickAttr = item.external
@@ -1518,6 +1795,7 @@
 
     // stash unpin callbacks indexed by position
     window._homePinnedCallbacks = items.map(i => i.unpin);
+    applyHomeLayout();
   }
 
   window._homePinnedUnpin = function(idx) {

--- a/server.js
+++ b/server.js
@@ -86,7 +86,86 @@ let cache = {
   issuesUpdatedAt: null,
   eventsUpdatedAt: null,
   tasksUpdatedAt: null,
+  notesUpdatedAt: null,
+  standupUpdatedAt: null,
+  analyticsUpdatedAt: null,
 };
+
+const SOURCE_CONFIG = {
+  github: { label: 'GitHub', staleAfterMs: 15 * 60 * 1000 },
+  calendar: { label: 'Calendar', staleAfterMs: 30 * 60 * 1000 },
+  tasks: { label: 'Tasks', staleAfterMs: 10 * 60 * 1000 },
+  notes: { label: 'Notes', staleAfterMs: 30 * 60 * 1000 },
+  standup: { label: 'Standup', staleAfterMs: 36 * 60 * 60 * 1000 },
+  prs: { label: 'PRs', staleAfterMs: 15 * 60 * 1000 },
+  analytics: { label: 'Analytics', staleAfterMs: 30 * 60 * 1000 },
+  infra: { label: 'Infra', staleAfterMs: 5 * 60 * 1000 },
+};
+
+let sourceState = Object.fromEntries(
+  Object.keys(SOURCE_CONFIG).map(key => [key, {
+    loading: true,
+    lastAttemptAt: null,
+    lastSuccessAt: null,
+    error: null,
+    errorAt: null,
+  }])
+);
+
+function beginSource(key) {
+  if (!sourceState[key]) return;
+  sourceState[key].loading = true;
+  sourceState[key].lastAttemptAt = Date.now();
+}
+
+function succeedSource(key, updatedAt = Date.now()) {
+  if (!sourceState[key]) return;
+  sourceState[key].loading = false;
+  sourceState[key].lastSuccessAt = updatedAt;
+  sourceState[key].error = null;
+  sourceState[key].errorAt = null;
+}
+
+function failSource(key, error) {
+  if (!sourceState[key]) return;
+  sourceState[key].loading = false;
+  sourceState[key].error = error?.message || String(error);
+  sourceState[key].errorAt = Date.now();
+}
+
+function sourceMeta(key, overrides = {}) {
+  const cfg = SOURCE_CONFIG[key] || { label: key, staleAfterMs: 15 * 60 * 1000 };
+  const state = sourceState[key] || {};
+  const now = Date.now();
+  const updatedAt = state.lastSuccessAt || null;
+  const ageMs = updatedAt ? now - updatedAt : null;
+
+  let status = 'fresh';
+  if (state.loading && !updatedAt) status = 'loading';
+  else if (!updatedAt && state.error) status = 'failed';
+  else if (updatedAt && state.error) status = 'stale';
+  else if (updatedAt && ageMs !== null && ageMs > cfg.staleAfterMs) status = 'stale';
+  else if (state.loading) status = 'refreshing';
+
+  return {
+    key,
+    label: cfg.label,
+    status,
+    loading: status === 'loading' || status === 'refreshing',
+    stale: status === 'stale',
+    updatedAt,
+    ageMs,
+    lastAttemptAt: state.lastAttemptAt || null,
+    error: state.error || null,
+    errorAt: state.errorAt || null,
+    staleAfterMs: cfg.staleAfterMs,
+    ...overrides,
+  };
+}
+
+function sourceResponseStatus(source) {
+  return source.status === 'failed' ? 500 : 503;
+}
 
 function parseTaskRecord(raw, label, color, section, completed = false) {
   const dueMatch = raw.match(/📅\s*(\d{4}-\d{2}-\d{2})/);
@@ -113,10 +192,12 @@ function parseTaskRecord(raw, label, color, section, completed = false) {
 // ── Pull Requests ───────────────────────────────────────────────────────────────
 function fetchPRs() {
   console.log('[prs] fetching open PRs...');
+  beginSource('prs');
   try {
     if (!ACTIVE_REPOS.length) {
       cache.prs = [];
       cache.prsUpdatedAt = Date.now();
+      succeedSource('prs', cache.prsUpdatedAt);
       console.log('[prs] skipped, no github.trackedRepos configured');
       return;
     }
@@ -138,8 +219,10 @@ function fetchPRs() {
     allPRs.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
     cache.prs = allPRs;
     cache.prsUpdatedAt = Date.now();
+    succeedSource('prs', cache.prsUpdatedAt);
     console.log(`[prs] fetched ${allPRs.length} open PRs`);
   } catch (err) {
+    failSource('prs', err);
     console.error('[prs] fetch error:', err.message);
   }
 }
@@ -238,15 +321,23 @@ function parseStandupSections(content) {
 
 function fetchStandup() {
   console.log('[standup] reading latest standup...');
+  beginSource('standup');
   try {
     if (!STANDUP_DIR || !fs.existsSync(STANDUP_DIR)) {
       cache.standup = null;
+      cache.standupUpdatedAt = Date.now();
+      succeedSource('standup', cache.standupUpdatedAt);
       return;
     }
     const files = fs.readdirSync(STANDUP_DIR)
       .filter(f => f.match(/^\d{4}-\d{2}-\d{2}\.md$/))
       .sort().reverse();
-    if (!files.length) { cache.standup = null; return; }
+    if (!files.length) {
+      cache.standup = null;
+      cache.standupUpdatedAt = Date.now();
+      succeedSource('standup', cache.standupUpdatedAt);
+      return;
+    }
 
     const latest = files[0];
     const date = latest.replace('.md', '');
@@ -263,8 +354,11 @@ function fetchStandup() {
       sections,
       raw: content,
     };
+    cache.standupUpdatedAt = Date.now();
+    succeedSource('standup', cache.standupUpdatedAt);
     console.log(`[standup] loaded ${date}, ${sections.length} repo sections`);
   } catch (err) {
+    failSource('standup', err);
     console.error('[standup] error:', err.message);
   }
 }
@@ -272,12 +366,15 @@ function fetchStandup() {
 // ── Notes ────────────────────────────────────────────────────────────────────
 function fetchNotes() {
   console.log('[notes] reading obsidian notes...');
+  beginSource('notes');
   try {
     const now = new Date();
     const result = { dailyNote: null, decisions: [], updatedAt: Date.now() };
 
     if (!DAILY_DIR && !DECISIONS_DIR) {
       cache.notes = result;
+      cache.notesUpdatedAt = result.updatedAt;
+      succeedSource('notes', cache.notesUpdatedAt);
       console.log('[notes] skipped, no obsidian daily/decisions paths configured');
       return;
     }
@@ -347,9 +444,12 @@ function fetchNotes() {
       }
     }
 
-      cache.notes = result;
+    cache.notes = result;
+    cache.notesUpdatedAt = result.updatedAt;
+    succeedSource('notes', cache.notesUpdatedAt);
     console.log(`[notes] daily note: ${result.dailyNote?.date || 'none'}, decisions: ${result.decisions.length}`);
   } catch (err) {
+    failSource('notes', err);
     console.error('[notes] error:', err.message);
   }
 }
@@ -357,6 +457,7 @@ function fetchNotes() {
 // ── Tasks ────────────────────────────────────────────────────────────────────
 function fetchTasks() {
   console.log('[tasks] reading obsidian tasks...');
+  beginSource('tasks');
   try {
     const result = [];
     const completed = [];
@@ -365,6 +466,7 @@ function fetchTasks() {
       cache.tasks = result;
       cache.completedTasks = completed;
       cache.tasksUpdatedAt = Date.now();
+      succeedSource('tasks', cache.tasksUpdatedAt);
       console.log('[tasks] skipped, no tasks config found');
       return;
     }
@@ -399,8 +501,10 @@ function fetchTasks() {
       return 0;
     });
     cache.tasksUpdatedAt = Date.now();
+    succeedSource('tasks', cache.tasksUpdatedAt);
     console.log(`[tasks] found ${result.length} open tasks, ${completed.length} completed tasks`);
   } catch (err) {
+    failSource('tasks', err);
     console.error('[tasks] error:', err.message);
   }
 }
@@ -408,11 +512,13 @@ function fetchTasks() {
 // ── GitHub ────────────────────────────────────────────────────────────────────
 function fetchGitHub() {
   console.log('[github] fetching issues...');
+  beginSource('github');
   try {
     if (!GITHUB_ORGS.length) {
       cache.issues = [];
       cache.repoStats = [];
       cache.issuesUpdatedAt = Date.now();
+      succeedSource('github', cache.issuesUpdatedAt);
       console.log('[github] skipped, no github.orgs configured');
       return;
     }
@@ -451,8 +557,10 @@ function fetchGitHub() {
     cache.issues = allIssues;
     cache.repoStats = repoStats;
     cache.issuesUpdatedAt = Date.now();
+    succeedSource('github', cache.issuesUpdatedAt);
     console.log(`[github] fetched ${allIssues.length} issues, ${repoStats.length} repos`);
   } catch (err) {
+    failSource('github', err);
     console.error('[github] fetch error:', err.message);
   }
 }
@@ -460,6 +568,7 @@ function fetchGitHub() {
 // ── Calendar ──────────────────────────────────────────────────────────────────
 async function fetchCalendars() {
   console.log('[calendar] fetching events...');
+  beginSource('calendar');
   try {
     const now = new Date();
     const windowEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days ahead
@@ -500,8 +609,10 @@ async function fetchCalendars() {
 
     cache.events = allEvents;
     cache.eventsUpdatedAt = Date.now();
+    succeedSource('calendar', cache.eventsUpdatedAt);
     console.log(`[calendar] fetched ${allEvents.length} events`);
   } catch (err) {
+    failSource('calendar', err);
     console.error('[calendar] fetch error:', err.message);
   }
 }
@@ -515,30 +626,39 @@ let umamiTokenExpiry = 0;
 
 async function getUmamiToken() {
   if (umamiToken && Date.now() < umamiTokenExpiry) return umamiToken;
+  const res = await fetch(`${UMAMI_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: UMAMI_USERNAME, password: UMAMI_PASSWORD }),
+    signal: AbortSignal.timeout(10000),
+  });
+  const text = await res.text();
+  let data = {};
   try {
-    const res = await fetch(`${UMAMI_URL}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username: UMAMI_USERNAME, password: UMAMI_PASSWORD }),
-      signal: AbortSignal.timeout(10000),
-    });
-    const data = await res.json();
-    umamiToken = data.token;
-    umamiTokenExpiry = Date.now() + 23 * 60 * 60 * 1000; // 23h
-    return umamiToken;
-  } catch (e) {
-    console.error('[umami] auth error:', e.message);
-    return null;
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    data = {};
   }
+  if (!res.ok || !data.token) {
+    throw new Error(data.error || data.message || `Umami auth failed (${res.status})`);
+  }
+  umamiToken = data.token;
+  umamiTokenExpiry = Date.now() + 23 * 60 * 60 * 1000; // 23h
+  return umamiToken;
 }
 
 async function fetchAnalytics() {
   console.log('[umami] fetchAnalytics called, URL:', UMAMI_URL ? 'set' : 'MISSING');
-  if (!UMAMI_URL || !UMAMI_USERNAME) { console.log('[umami] skipping - missing config'); return; }
+  beginSource('analytics');
+  if (!UMAMI_URL || !UMAMI_USERNAME) {
+    const err = new Error('Umami is not configured');
+    failSource('analytics', err);
+    console.log('[umami] skipping - missing config');
+    return;
+  }
   console.log('[umami] fetching analytics...');
   try {
     const token = await getUmamiToken();
-    if (!token) return;
 
     const endAt = Date.now();
     const startAt = endAt - 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -597,8 +717,11 @@ async function fetchAnalytics() {
       updatedAt: new Date().toISOString(),
       range: '30d',
     };
+    cache.analyticsUpdatedAt = Date.now();
+    succeedSource('analytics', cache.analyticsUpdatedAt);
     console.log(`[umami] fetched ${siteStats.length} sites, ${totals.pageviews} total pageviews`);
   } catch (e) {
+    failSource('analytics', e);
     console.error('[umami] fetch error:', e.message);
   }
 }
@@ -624,28 +747,39 @@ fetchAnalytics();
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/api/issues', (req, res) => {
-  if (!cache.issues) return res.status(503).json({ ok: false, error: 'loading' });
+  const source = sourceMeta('github');
+  if (!cache.issues) {
+    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+  }
   const urgent = cache.issues.filter(i => i.priority === 'urgent');
   const active = cache.issues.filter(i => i.priority === 'active');
   const deferred = cache.issues.filter(i => i.priority === 'deferred');
-  res.json({ ok: true, urgent, active, deferred, total: cache.issues.length, updatedAt: cache.issuesUpdatedAt });
+  res.json({ ok: true, urgent, active, deferred, total: cache.issues.length, updatedAt: cache.issuesUpdatedAt, source });
 });
 
 app.get('/api/repos', (req, res) => {
-  if (!cache.repoStats) return res.status(503).json({ ok: false, error: 'loading' });
-  res.json({ ok: true, repos: cache.repoStats, updatedAt: cache.issuesUpdatedAt });
+  const source = sourceMeta('github');
+  if (!cache.repoStats) {
+    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+  }
+  res.json({ ok: true, repos: cache.repoStats, updatedAt: cache.issuesUpdatedAt, source });
 });
 
 app.get('/api/calendar', (req, res) => {
-  if (!cache.events) return res.status(503).json({ ok: false, error: 'loading' });
-  res.json({ ok: true, events: cache.events, updatedAt: cache.eventsUpdatedAt });
+  const source = sourceMeta('calendar');
+  if (!cache.events) {
+    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+  }
+  res.json({ ok: true, events: cache.events, updatedAt: cache.eventsUpdatedAt, source });
 });
 
 // Infra — PM2 process list
 app.get('/api/infra', (req, res) => {
+  beginSource('infra');
   try {
     const raw = execSync('pm2 jlist', { encoding: 'utf8' });
     const processes = JSON.parse(raw);
+    const updatedAt = Date.now();
     const data = processes.map(p => ({
       id: p.pm_id,
       name: p.name,
@@ -656,34 +790,50 @@ app.get('/api/infra', (req, res) => {
       cpu: p.monit?.cpu ?? 0,
       memory: p.monit?.memory ?? 0,
     }));
-    res.json({ ok: true, processes: data, updatedAt: Date.now() });
+    succeedSource('infra', updatedAt);
+    res.json({ ok: true, processes: data, updatedAt, source: sourceMeta('infra') });
   } catch (err) {
-    res.status(500).json({ ok: false, error: err.message });
+    failSource('infra', err);
+    const source = sourceMeta('infra');
+    res.status(sourceResponseStatus(source)).json({ ok: false, error: err.message, processes: [], updatedAt: source.updatedAt, source });
   }
 });
 
 app.get('/api/tasks', (req, res) => {
-  if (!cache.tasks) return res.status(503).json({ ok: false, error: 'loading' });
-  res.json({ ok: true, tasks: cache.tasks, completedTasks: cache.completedTasks || [], updatedAt: cache.tasksUpdatedAt });
+  const source = sourceMeta('tasks');
+  if (!cache.tasks) {
+    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+  }
+  res.json({ ok: true, tasks: cache.tasks, completedTasks: cache.completedTasks || [], updatedAt: cache.tasksUpdatedAt, source });
 });
 
 app.get('/api/prs', (req, res) => {
-  if (!cache.prs) return res.status(503).json({ ok: false, error: 'loading' });
-  res.json({ ok: true, prs: cache.prs, updatedAt: cache.prsUpdatedAt });
+  const source = sourceMeta('prs');
+  if (!cache.prs) {
+    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+  }
+  res.json({ ok: true, prs: cache.prs, updatedAt: cache.prsUpdatedAt, source });
 });
 
 app.get('/api/standup', (req, res) => {
-  res.json({ ok: true, standup: cache.standup || null });
+  const source = sourceMeta('standup');
+  res.json({ ok: true, standup: cache.standup || null, updatedAt: cache.standupUpdatedAt, source });
 });
 
 app.get('/api/analytics', (req, res) => {
-  if (!cache.analytics) return res.status(503).json({ ok: false, error: 'loading' });
-  res.json(cache.analytics);
+  const source = sourceMeta('analytics');
+  if (!cache.analytics) {
+    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+  }
+  res.json({ ok: true, ...cache.analytics, source });
 });
 
 app.get('/api/notes', (req, res) => {
-  if (!cache.notes) return res.status(503).json({ ok: false, error: 'loading' });
-  res.json({ ok: true, ...cache.notes });
+  const source = sourceMeta('notes');
+  if (!cache.notes) {
+    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+  }
+  res.json({ ok: true, ...cache.notes, source });
 });
 
 // Quick issue close


### PR DESCRIPTION
## Summary
- add per-source freshness, stale, and failure metadata to command-center APIs and surface it in view subtitles
- standardize empty and unavailable panel states with reusable state cards across the dashboard
- add Home layout controls for compact mode, collapse, hide, reorder, and pin-to-top with local persistence

## Testing
- node --check server.js
- extract inline script from public/index.html and run node --check
- run command-center locally with a temporary config and verify the new Home layout controls render
- verify API source metadata on /api/issues and /api/infra

Closes #48
Closes #60
Closes #59
