### PR TITLE
Migrate Angular daily-use views and Home dashboard

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,21 +1,91 @@
 import { Routes } from '@angular/router';
 
 import { HomePage } from './features/home/home.page';
+import { IssueListPage } from './features/issues/issue-list.page';
+import { PrsPage } from './features/prs/prs.page';
 import { PlaceholderPageComponent } from './features/shared/placeholder-page.component';
+import { DonePage } from './features/tasks/done.page';
+import { TasksPage } from './features/tasks/tasks.page';
 
 export const routes: Routes = [
   {
     path: '',
     component: HomePage,
-    title: 'Command Center Rewrite Scaffold',
+    title: 'Command Center Home',
   },
   {
-    path: 'issues',
-    component: PlaceholderPageComponent,
-    title: 'Issues Migration Target',
+    path: 'issues/urgent',
+    component: IssueListPage,
+    title: 'Urgent Issues',
     data: {
-      title: 'Issues migration target',
-      description: 'This route establishes where the Angular issue views will land once issue #71 begins. For now it exists to prove the new route shell and feature structure.',
+      priority: 'urgent',
+      eyebrow: 'Layer 1',
+      title: 'Urgent Issues',
+      subtitle: 'Critical and bug-heavy work that needs the fastest attention.',
+    },
+  },
+  {
+    path: 'issues/active',
+    component: IssueListPage,
+    title: 'Active Issues',
+    data: {
+      priority: 'active',
+      eyebrow: 'Layer 1',
+      title: 'Active Issues',
+      subtitle: 'In-progress work and the main queue of issues that are currently active.',
+    },
+  },
+  {
+    path: 'issues/backlog',
+    component: IssueListPage,
+    title: 'Backlog Issues',
+    data: {
+      priority: 'backlog',
+      eyebrow: 'Layer 1',
+      title: 'Backlog Issues',
+      subtitle: 'Deferred work and the longer queue waiting behind the current focus.',
+    },
+  },
+  {
+    path: 'prs',
+    component: PrsPage,
+    title: 'Pull Requests',
+  },
+  {
+    path: 'tasks',
+    component: TasksPage,
+    title: 'Tasks',
+  },
+  {
+    path: 'done',
+    component: DonePage,
+    title: 'Completed Tasks',
+  },
+  {
+    path: 'calendar',
+    component: PlaceholderPageComponent,
+    title: 'Calendar Migration Target',
+    data: {
+      title: 'Calendar migration target',
+      description: 'The dedicated Calendar page is still part of issue #72, but the Home dashboard already consumes calendar data through the shared resource layer.',
+    },
+  },
+  {
+    path: 'repos',
+    component: PlaceholderPageComponent,
+    title: 'Repos Migration Target',
+    data: {
+      title: 'Repository migration target',
+      description: 'The dedicated Repositories page remains in issue #72. Home can still surface repo summaries and pinned repo items in the meantime.',
+    },
+  },
+  {
+    path: 'infra',
+    component: PlaceholderPageComponent,
+    title: 'Infra Migration Target',
+    data: {
+      title: 'Infrastructure migration target',
+      description: 'The dedicated Infrastructure page remains in issue #72, but Home can already show a lightweight infra summary from the shared resource layer.',
     },
   },
   {
@@ -24,7 +94,7 @@ export const routes: Routes = [
     title: 'Notes Migration Target',
     data: {
       title: 'Notes migration target',
-      description: 'This route marks the future Angular landing zone for Notes, Standup, Calendar, Repos, Infra, and Analytics work tracked in issue #72.',
+      description: 'The dedicated Notes view remains part of issue #72, while Home already uses the shared notes and standup resources.',
     },
   },
   {

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -17,10 +17,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render the shared shell heading', async () => {
+  it('should render the Angular daily-views heading', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Shared Angular shell and UI primitives');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Angular daily-use views are live');
   });
 });

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -11,8 +11,13 @@ import { NavItem } from './shared/models/nav-item';
 })
 export class App {
   protected readonly navItems: NavItem[] = [
-    { path: '/', label: 'Scaffold Home' },
-    { path: '/issues', label: 'Issue Views' },
-    { path: '/notes', label: 'Secondary Views' },
+    { path: '/', label: 'Home' },
+    { path: '/issues/urgent', label: 'Urgent' },
+    { path: '/issues/active', label: 'Active' },
+    { path: '/issues/backlog', label: 'Backlog' },
+    { path: '/prs', label: 'PRs' },
+    { path: '/tasks', label: 'Tasks' },
+    { path: '/done', label: 'Done' },
+    { path: '/notes', label: 'Next up' },
   ];
 }

--- a/frontend/src/app/core/api/command-center-api.service.ts
+++ b/frontend/src/app/core/api/command-center-api.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import {
   AnalyticsResponse,
   CalendarResponse,
+  CloseIssueResponse,
   InfraResponse,
   IssuesResponse,
   NotesResponse,
@@ -57,5 +58,9 @@ export class CommandCenterApiService {
 
   refreshAll(): Observable<RefreshResponse> {
     return this.http.post<RefreshResponse>('/api/refresh', {});
+  }
+
+  closeIssue(owner: string, repo: string, number: number): Observable<CloseIssueResponse> {
+    return this.http.post<CloseIssueResponse>(`/api/issues/${owner}/${repo}/${number}/close`, {});
   }
 }

--- a/frontend/src/app/core/data/dashboard-data.service.ts
+++ b/frontend/src/app/core/data/dashboard-data.service.ts
@@ -31,7 +31,7 @@ export class DashboardDataService {
   private prsResource?: DashboardResource<PrsResponse['prs']>;
   private standupResource?: DashboardResource<StandupResponse['standup']>;
   private analyticsResource?: DashboardResource<{ totals: AnalyticsResponse['totals']; sites: AnalyticsResponse['sites']; range: AnalyticsResponse['range']; updatedAt: AnalyticsResponse['updatedAt'] }>;
-  private notesResource?: DashboardResource<{ daily: NotesResponse['daily']; decisions: NotesResponse['decisions'] }>;
+  private notesResource?: DashboardResource<{ dailyNote: NotesResponse['dailyNote']; decisions: NotesResponse['decisions'] }>;
 
   issues(): DashboardResource<IssuesViewModel> {
     return this.issuesResource ??= createDashboardResource({
@@ -117,12 +117,26 @@ export class DashboardDataService {
     });
   }
 
-  notes(): DashboardResource<{ daily: NotesResponse['daily']; decisions: NotesResponse['decisions'] }> {
+  notes(): DashboardResource<{ dailyNote: NotesResponse['dailyNote']; decisions: NotesResponse['decisions'] }> {
     return this.notesResource ??= createDashboardResource({
       load: () => this.api.getNotes(),
-      selectData: (response: NotesResponse) => ({ daily: response.daily, decisions: response.decisions }),
-      isEmpty: (data) => !data.daily && data.decisions.length === 0,
+      selectData: (response: NotesResponse) => ({ dailyNote: response.dailyNote, decisions: response.decisions }),
+      isEmpty: (data) => !data.dailyNote && data.decisions.length === 0,
       intervalMs: 180_000,
+    });
+  }
+
+  closeIssue(repoFull: string, number: number): void {
+    const [owner, repo] = repoFull.split('/');
+    if (!owner || !repo) return;
+
+    this.api.closeIssue(owner, repo, number).pipe(take(1)).subscribe({
+      next: () => {
+        this.issuesResource?.refresh();
+      },
+      error: () => {
+        this.issuesResource?.refresh();
+      },
     });
   }
 

--- a/frontend/src/app/core/state/home-layout.service.ts
+++ b/frontend/src/app/core/state/home-layout.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface HomeLayoutState {
+  order: string[];
+  hidden: string[];
+  collapsed: string[];
+  compact: boolean;
+}
+
+const HOME_LAYOUT_STORAGE_KEY = 'cc-home-layout';
+
+export const DEFAULT_HOME_LAYOUT: HomeLayoutState = {
+  order: ['pinned', 'upcoming', 'issues', 'tasks', 'daily-note', 'standup'],
+  hidden: [],
+  collapsed: [],
+  compact: false,
+};
+
+@Injectable({ providedIn: 'root' })
+export class HomeLayoutService {
+  private readonly layoutState = signal<HomeLayoutState>(this.load());
+  private readonly customize = signal(false);
+
+  readonly layout = this.layoutState.asReadonly();
+  readonly customizeMode = this.customize.asReadonly();
+
+  toggleCompact(): void {
+    this.update((layout) => ({ ...layout, compact: !layout.compact }));
+  }
+
+  toggleCustomize(): void {
+    this.customize.update((value) => !value);
+  }
+
+  reset(): void {
+    this.layoutState.set({ ...DEFAULT_HOME_LAYOUT });
+    this.customize.set(false);
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, JSON.stringify(DEFAULT_HOME_LAYOUT));
+  }
+
+  toggleCollapsed(sectionId: string): void {
+    this.update((layout) => ({
+      ...layout,
+      collapsed: layout.collapsed.includes(sectionId)
+        ? layout.collapsed.filter((id) => id !== sectionId)
+        : [...layout.collapsed, sectionId],
+    }));
+  }
+
+  toggleHidden(sectionId: string): void {
+    this.update((layout) => ({
+      ...layout,
+      hidden: layout.hidden.includes(sectionId)
+        ? layout.hidden.filter((id) => id !== sectionId)
+        : [...layout.hidden, sectionId],
+    }));
+  }
+
+  restore(sectionId: string): void {
+    this.update((layout) => ({
+      ...layout,
+      hidden: layout.hidden.filter((id) => id !== sectionId),
+    }));
+  }
+
+  move(sectionId: string, delta: number): void {
+    this.update((layout) => {
+      const order = [...layout.order];
+      const index = order.indexOf(sectionId);
+      if (index === -1) return layout;
+
+      const nextIndex = Math.max(0, Math.min(order.length - 1, index + delta));
+      if (index === nextIndex) return layout;
+
+      const [item] = order.splice(index, 1);
+      order.splice(nextIndex, 0, item);
+      return { ...layout, order };
+    });
+  }
+
+  pinToTop(sectionId: string): void {
+    this.update((layout) => ({
+      ...layout,
+      order: [sectionId, ...layout.order.filter((id) => id !== sectionId)],
+    }));
+  }
+
+  private load(): HomeLayoutState {
+    try {
+      return this.sanitize(JSON.parse(localStorage.getItem(HOME_LAYOUT_STORAGE_KEY) || '{}'));
+    } catch {
+      return { ...DEFAULT_HOME_LAYOUT };
+    }
+  }
+
+  private sanitize(layout: Partial<HomeLayoutState>): HomeLayoutState {
+    const allowed = DEFAULT_HOME_LAYOUT.order;
+    const incomingOrder = Array.isArray(layout.order) ? layout.order : [];
+    const order = [...new Set(incomingOrder.filter((id) => allowed.includes(id)).concat(allowed.filter((id) => !incomingOrder.includes(id))))];
+    const hidden = [...new Set((Array.isArray(layout.hidden) ? layout.hidden : []).filter((id) => allowed.includes(id)))];
+    const collapsed = [...new Set((Array.isArray(layout.collapsed) ? layout.collapsed : []).filter((id) => allowed.includes(id)))];
+    return { order, hidden, collapsed, compact: !!layout.compact };
+  }
+
+  private update(mutator: (layout: HomeLayoutState) => HomeLayoutState): void {
+    const next = this.sanitize(mutator(this.layoutState()));
+    this.layoutState.set(next);
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, JSON.stringify(next));
+  }
+}

--- a/frontend/src/app/core/state/pin.service.ts
+++ b/frontend/src/app/core/state/pin.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, signal } from '@angular/core';
+
+export type PinType = 'issue' | 'pr' | 'task' | 'event' | 'repo';
+
+const PIN_STORAGE_KEY = 'cc-pinned';
+
+@Injectable({ providedIn: 'root' })
+export class PinService {
+  private readonly pins = signal<Record<string, boolean>>(this.load());
+
+  readonly state = this.pins.asReadonly();
+
+  isPinned(type: PinType, id: string): boolean {
+    return !!this.pins()[this.key(type, id)];
+  }
+
+  toggle(type: PinType, id: string): void {
+    const key = this.key(type, id);
+    const next = { ...this.pins() };
+
+    if (next[key]) {
+      delete next[key];
+    } else {
+      next[key] = true;
+    }
+
+    this.persist(next);
+  }
+
+  private key(type: PinType, id: string): string {
+    return `${type}:${id}`;
+  }
+
+  private load(): Record<string, boolean> {
+    try {
+      return JSON.parse(localStorage.getItem(PIN_STORAGE_KEY) || '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  private persist(next: Record<string, boolean>): void {
+    this.pins.set(next);
+    localStorage.setItem(PIN_STORAGE_KEY, JSON.stringify(next));
+  }
+}

--- a/frontend/src/app/core/state/reminders.service.ts
+++ b/frontend/src/app/core/state/reminders.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface ReminderItem {
+  id: string;
+  text: string;
+  due: string | null;
+  createdAt: string;
+}
+
+const REMINDER_STORAGE_KEY = 'cc-reminders';
+
+@Injectable({ providedIn: 'root' })
+export class RemindersService {
+  private readonly itemsState = signal<ReminderItem[]>(this.load());
+
+  readonly items = this.itemsState.asReadonly();
+
+  add(text: string, due: string | null): void {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    this.persist([
+      ...this.itemsState(),
+      {
+        id: Date.now().toString(36),
+        text: trimmed,
+        due,
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+  }
+
+  update(id: string, text: string, due: string | null): void {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    this.persist(this.itemsState().map((item) => item.id === id ? { ...item, text: trimmed, due } : item));
+  }
+
+  remove(id: string): void {
+    this.persist(this.itemsState().filter((item) => item.id !== id));
+  }
+
+  complete(id: string): void {
+    this.remove(id);
+  }
+
+  private load(): ReminderItem[] {
+    try {
+      return JSON.parse(localStorage.getItem(REMINDER_STORAGE_KEY) || '[]');
+    } catch {
+      return [];
+    }
+  }
+
+  private persist(items: ReminderItem[]): void {
+    this.itemsState.set(items);
+    localStorage.setItem(REMINDER_STORAGE_KEY, JSON.stringify(items));
+  }
+}

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -1,160 +1,574 @@
-import { DatePipe } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, HostListener, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { HomeLayoutService } from '../../core/state/home-layout.service';
+import { PinService } from '../../core/state/pin.service';
+import { ReminderItem, RemindersService } from '../../core/state/reminders.service';
+import { CalendarEvent, IssueItem, PullRequestItem, RepoSummary, TaskItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
 import { CardComponent } from '../../shared/ui/card.component';
 import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
-import { StatCardComponent } from '../../shared/ui/stat-card.component';
-import { StatusBadgeComponent } from '../../shared/ui/status-badge.component';
+
+interface PinnedHomeItem {
+  type: 'Issue' | 'PR' | 'Task' | 'Event' | 'Repo';
+  title: string;
+  meta: string;
+  externalUrl?: string;
+  route?: string;
+  unpin: () => void;
+}
 
 @Component({
   selector: 'app-home-page',
-  imports: [
-    DatePipe,
-    ViewShellComponent,
-    CardComponent,
-    PillComponent,
-    StatePanelComponent,
-    StatCardComponent,
-    StatusBadgeComponent,
-  ],
+  imports: [ViewShellComponent, CardComponent, PillComponent, StatePanelComponent],
   template: `
     <app-view-shell
-      eyebrow="Issue #70"
-      title="Angular now has a shared data layer"
-      subtitle="Polling, refresh behavior, freshness metadata, and degraded-state handling are now centralized so future Angular views can compose data instead of hand-rolling fetch logic."
-      meta="Next up: #71 first real feature migration onto the shell and data layer"
+      eyebrow="Layer 2"
+      title="Home dashboard"
+      subtitle="Angular Home now carries the daily command-center view, including reminders, pinned items, upcoming events, issue/task summaries, the latest daily note, and standup context."
+      [meta]="homeMeta()"
     >
-      <div view-actions>
-        <cc-pill tone="accent">Shared resources</cc-pill>
-        <cc-pill tone="info">Polling + freshness</cc-pill>
-        <button
-          type="button"
-          (click)="refreshAll()"
-          [disabled]="refreshingAll()"
-          class="inline-flex items-center gap-2 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)] disabled:cursor-not-allowed disabled:opacity-60"
-        >
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="accent">Angular Home</cc-pill>
+        <cc-pill tone="info">Two-layer migration</cc-pill>
+        <button type="button" (click)="refreshAll()" [disabled]="refreshingAll()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)] disabled:cursor-not-allowed disabled:opacity-60">
           {{ refreshingAll() ? 'Refreshing…' : 'Refresh sources' }}
         </button>
       </div>
 
-      <section class="grid gap-4 xl:grid-cols-3">
-        <cc-stat-card label="API layer" value="9 endpoints" hint="Typed accessors exist for issues, repos, calendar, infra, tasks, PRs, standup, analytics, and notes." tone="accent"></cc-stat-card>
-        <cc-stat-card label="Refresh model" value="Centralized" hint="Polling and manual refresh live in one place instead of scattered across pages." tone="success"></cc-stat-card>
-        <cc-stat-card label="Next migration" value="#71" hint="Home, Issues, PRs, and Tasks can now consume shared resources instead of local HttpClient logic." tone="warning"></cc-stat-card>
+      <cc-card eyebrow="Today" title="command.center" [description]="tagline()" tone="highlight" [compact]="true">
+        <section class="grid gap-4 lg:grid-cols-5">
+          <button type="button" (click)="go('/issues/urgent')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-rose-300/40">
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Urgent</div>
+            <div class="mt-3 text-3xl font-semibold text-rose-300">{{ issues.data()?.counts?.urgent ?? 0 }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">bugs and critical work</div>
+          </button>
+          <button type="button" (click)="go('/issues/active')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-amber-300/40">
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Active</div>
+            <div class="mt-3 text-3xl font-semibold text-amber-300">{{ issues.data()?.counts?.active ?? 0 }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">in-progress issues</div>
+          </button>
+          <button type="button" (click)="go('/issues/backlog')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-slate-300/40">
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Backlog</div>
+            <div class="mt-3 text-3xl font-semibold text-slate-300">{{ issues.data()?.counts?.deferred ?? 0 }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ issues.data()?.total ?? 0 }} total open</div>
+          </button>
+          <button type="button" (click)="go('/tasks')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-fuchsia-300/40">
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Tasks</div>
+            <div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ tasks.data()?.open?.length ?? 0 }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">open in Obsidian</div>
+          </button>
+          <button type="button" (click)="go('/infra')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-emerald-300/40">
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Infra</div>
+            @if (infra.hasData()) {
+              <div class="mt-3 text-3xl font-semibold text-emerald-300">{{ onlineServices() }}<span class="text-base font-medium text-[var(--cc-text-soft)]">/{{ infra.data()?.length ?? 0 }}</span></div>
+              <div class="mt-2 text-sm text-[var(--cc-text-muted)]">services online</div>
+            } @else {
+              <div class="mt-3 text-3xl font-semibold text-[var(--cc-text-soft)]">—</div>
+              <div class="mt-2 text-sm text-[var(--cc-text-muted)]">monitoring unavailable</div>
+            }
+          </button>
+        </section>
+      </cc-card>
+
+      <cc-card eyebrow="Reminders" title="Keep the little stuff visible" [compact]="true">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p class="text-sm text-[var(--cc-text-muted)]">Quick capture for things you do not want falling through the cracks.</p>
+          </div>
+          <button type="button" (click)="openReminderComposer()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">＋ Add</button>
+        </div>
+
+        @if (composerOpen()) {
+          <div class="mt-4 grid gap-3 rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4 md:grid-cols-[1fr_180px_auto_auto]">
+            <input [value]="reminderText()" (input)="reminderText.set($any($event.target).value)" (keydown)="onReminderKeydown($event)" class="rounded-xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-4 py-3 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="What do you need to remember?" />
+            <input [value]="reminderDue() || ''" (input)="reminderDue.set($any($event.target).value || null)" type="date" class="rounded-xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-4 py-3 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" />
+            <button type="button" (click)="saveReminder()" class="rounded-xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-3 text-sm font-medium text-emerald-200">{{ editingReminderId() ? 'Save' : 'Add' }}</button>
+            <button type="button" (click)="cancelReminderEdit()" class="rounded-xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-4 py-3 text-sm font-medium text-[var(--cc-text-muted)]">Cancel</button>
+          </div>
+        }
+
+        <div class="mt-4 space-y-3">
+          @if (!reminders.items().length) {
+            <cc-state-panel kind="empty" title="No reminders yet" message="Add one above, or press N while on Home to capture a quick reminder."></cc-state-panel>
+          } @else {
+            @for (reminder of reminders.items(); track reminder.id) {
+              <div class="flex items-center gap-3 rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-3">
+                <button type="button" (click)="completeReminder(reminder.id)" class="h-5 w-5 rounded-full border border-[var(--cc-border)]"></button>
+                <div class="min-w-0 flex-1">
+                  <div class="truncate text-sm font-medium text-[var(--cc-text)]">{{ reminder.text }}</div>
+                  @if (reminder.due) {
+                    <div class="mt-1 text-xs text-[var(--cc-text-soft)]">📅 {{ reminder.due }}</div>
+                  }
+                </div>
+                <button type="button" (click)="editReminder(reminder)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Edit</button>
+                <button type="button" (click)="dismissReminder(reminder.id)" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">Dismiss</button>
+              </div>
+            }
+          }
+        </div>
+      </cc-card>
+
+      <section class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-6 md:p-7">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div class="text-sm font-semibold text-[var(--cc-text)]">Home layout</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ layoutSummary() }}</div>
+          </div>
+          <div class="flex flex-wrap gap-3">
+            <button type="button" (click)="homeLayout.toggleCompact()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)]">{{ homeLayout.layout().compact ? 'Compact on' : 'Compact mode' }}</button>
+            <button type="button" (click)="homeLayout.toggleCustomize()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)]">{{ homeLayout.customizeMode() ? 'Done customizing' : 'Customize' }}</button>
+            <button type="button" (click)="homeLayout.reset()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)]">Reset layout</button>
+          </div>
+        </div>
+
+        @if (hiddenSections().length) {
+          <div class="mt-4 flex flex-wrap gap-2">
+            @for (sectionId of hiddenSections(); track sectionId) {
+              <button type="button" (click)="homeLayout.restore(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Show {{ sectionLabel(sectionId) }}</button>
+            }
+          </div>
+        }
       </section>
 
-      <section class="grid gap-6 xl:grid-cols-[1.4fr_0.95fr]">
-        <cc-card
-          eyebrow="Data layer overview"
-          title="What #70 adds"
-          description="The frontend now has a shared data service that wraps the existing Express endpoints, normalizes source metadata, and defines one polling/refresh path for the rewrite."
-        >
-          <div class="grid gap-3 md:grid-cols-2">
-            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
-              <p class="text-sm font-semibold text-[var(--cc-text)]">Typed API access</p>
-              <p class="mt-2 text-sm leading-6 text-[var(--cc-text-muted)]">All current backend endpoints now have Angular accessors instead of ad hoc page-level requests.</p>
-            </div>
-            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
-              <p class="text-sm font-semibold text-[var(--cc-text)]">Polled resources</p>
-              <p class="mt-2 text-sm leading-6 text-[var(--cc-text-muted)]">Each source uses a shared resource model with loading, refreshing, empty, ready, and unavailable handling.</p>
-            </div>
-            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
-              <p class="text-sm font-semibold text-[var(--cc-text)]">Freshness-aware UI</p>
-              <p class="mt-2 text-sm leading-6 text-[var(--cc-text-muted)]">Backend source metadata now drives consistent stale, refreshing, and failed-state badges in the Angular shell.</p>
-            </div>
-            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
-              <p class="text-sm font-semibold text-[var(--cc-text)]">Central refresh</p>
-              <p class="mt-2 text-sm leading-6 text-[var(--cc-text-muted)]">Manual refresh now has one home, which will make upcoming feature views much cleaner.</p>
-            </div>
-          </div>
-        </cc-card>
-
-        <cc-card eyebrow="Live resource proof" title="Issues resource from shared data layer" tone="muted">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <p class="text-sm text-[var(--cc-text-muted)]">This panel is now powered by the shared resource layer rather than page-local HttpClient subscriptions.</p>
-            </div>
-            <cc-status-badge [tone]="badgeTone()">{{ badgeLabel() }}</cc-status-badge>
-          </div>
-
-          @if (issues.isLoading()) {
-            <cc-state-panel
-              kind="loading"
-              title="Loading issues resource"
-              message="The shared Angular data layer is fetching /api/issues and normalizing the source metadata for the UI."
-            ></cc-state-panel>
-          } @else if (issues.isUnavailable()) {
-            <cc-state-panel
-              kind="unavailable"
-              title="Issues resource unavailable"
-              [message]="issues.error() || 'The backend could not return issue data.'"
-            ></cc-state-panel>
-          } @else if (issues.isEmpty()) {
-            <cc-state-panel
-              kind="empty"
-              title="No issues returned"
-              message="The shared issues resource is healthy, but the current payload is empty."
-            ></cc-state-panel>
-          } @else if (issues.data()) {
-            <div class="space-y-4">
-              <div class="grid gap-4 sm:grid-cols-3">
-                <cc-stat-card label="Open issues" [value]="issues.data()!.total" hint="Across the tracked GitHub set."></cc-stat-card>
-                <cc-stat-card label="Urgent" [value]="issues.data()!.counts.urgent" hint="High-priority items surfaced by the backend."></cc-stat-card>
-                <cc-stat-card label="Active" [value]="issues.data()!.counts.active" hint="Currently active items from the shared issues resource."></cc-stat-card>
-              </div>
-
-              <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4 text-sm leading-6 text-[var(--cc-text-muted)]">
-                <p><span class="text-[var(--cc-text-soft)]">Source:</span> {{ issues.source()?.label }}</p>
-                <p class="mt-2"><span class="text-[var(--cc-text-soft)]">Source state:</span> {{ issues.source()?.status }}</p>
-                <p class="mt-2"><span class="text-[var(--cc-text-soft)]">Resource state:</span> {{ issues.state().stage }}</p>
-                <p class="mt-2">
-                  <span class="text-[var(--cc-text-soft)]">Last update:</span>
-                  @if (issues.data()!.updatedAt) {
-                    {{ issues.data()!.updatedAt! | date:'medium' }}
-                  } @else {
-                    Never
+      <section class="grid gap-6" [class.lg:grid-cols-3]="!homeLayout.layout().compact" [class.lg:grid-cols-2]="homeLayout.layout().compact">
+        @for (sectionId of homeLayout.layout().order; track sectionId; let index = $index) {
+          @if (!isSectionHidden(sectionId)) {
+            <article class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-6 md:p-7" [class.lg:col-span-3]="sectionId === 'pinned' || sectionId === 'daily-note' || sectionId === 'standup'" [class.opacity-90]="homeLayout.layout().compact">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0">
+                  <div class="text-lg font-semibold tracking-tight text-[var(--cc-text)]">{{ sectionLabel(sectionId) }}</div>
+                </div>
+                <div class="flex flex-wrap justify-end gap-2">
+                  <button type="button" (click)="homeLayout.toggleCollapsed(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ isSectionCollapsed(sectionId) ? 'Expand' : 'Collapse' }}</button>
+                  @if (homeLayout.customizeMode()) {
+                    <button type="button" (click)="homeLayout.pinToTop(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Top</button>
+                    <button type="button" (click)="homeLayout.move(sectionId, -1)" [disabled]="index === 0" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)] disabled:opacity-50">↑</button>
+                    <button type="button" (click)="homeLayout.move(sectionId, 1)" [disabled]="index === homeLayout.layout().order.length - 1" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)] disabled:opacity-50">↓</button>
+                    <button type="button" (click)="homeLayout.toggleHidden(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Hide</button>
                   }
-                </p>
+                </div>
               </div>
-            </div>
+
+              @if (!isSectionCollapsed(sectionId)) {
+                <div class="mt-5">
+                  @switch (sectionId) {
+                    @case ('pinned') {
+                      @if (!pinnedHomeItems().length) {
+                        <cc-state-panel kind="empty" title="Nothing pinned yet" message="Pin an issue, PR, task, event, or repo to keep it at the top of Home."></cc-state-panel>
+                      } @else {
+                        <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                          @for (item of pinnedHomeItems(); track item.type + ':' + item.title + ':' + item.meta) {
+                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                              <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0 flex-1">
+                                  <div class="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">{{ item.type }}</div>
+                                  <div class="mt-2 truncate text-sm font-semibold text-[var(--cc-text)]">{{ item.title }}</div>
+                                  <div class="mt-2 text-xs leading-5 text-[var(--cc-text-soft)]">{{ item.meta }}</div>
+                                </div>
+                                <button type="button" (click)="item.unpin()" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">×</button>
+                              </div>
+                              @if (item.externalUrl) {
+                                <a [href]="item.externalUrl" target="_blank" class="mt-4 inline-flex text-xs font-semibold uppercase tracking-[0.18em] text-amber-300">Open</a>
+                              } @else if (item.route) {
+                                <button type="button" (click)="go(item.route)" class="mt-4 inline-flex text-xs font-semibold uppercase tracking-[0.18em] text-amber-300">Open</button>
+                              }
+                            </div>
+                          }
+                        </div>
+                      }
+                    }
+                    @case ('upcoming') {
+                      @if (calendar.isLoading()) {
+                        <cc-state-panel kind="loading" title="Loading upcoming events" message="Reading the current calendar window for the Home dashboard."></cc-state-panel>
+                      } @else if (calendar.isUnavailable()) {
+                        <cc-state-panel kind="unavailable" title="Calendar unavailable" [message]="calendar.error() || 'Upcoming events could not be loaded.'"></cc-state-panel>
+                      } @else if (!upcomingEvents().length) {
+                        <cc-state-panel kind="empty" title="No upcoming events" message="Nothing is scheduled in the current window."></cc-state-panel>
+                      } @else {
+                        <div class="space-y-3">
+                          @for (event of upcomingEvents(); track eventKey(event)) {
+                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                              <div class="flex items-start justify-between gap-3">
+                                <div>
+                                  <div class="text-sm font-semibold text-[var(--cc-text)]">{{ event.title }}</div>
+                                  <div class="mt-2 text-xs leading-5 text-[var(--cc-text-soft)]">{{ eventDateLabel(event) }} · {{ eventTimeLabel(event) }} · {{ event.calendar }}</div>
+                                </div>
+                                <button type="button" (click)="togglePinnedEvent(event)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ pins.isPinned('event', eventKey(event)) ? 'Unpin' : 'Pin' }}</button>
+                              </div>
+                            </div>
+                          }
+                        </div>
+                      }
+                    }
+                    @case ('issues') {
+                      @if (issues.isLoading()) {
+                        <cc-state-panel kind="loading" title="Loading recent issues" message="Reading urgent and active issues for the Home dashboard."></cc-state-panel>
+                      } @else if (issues.isUnavailable()) {
+                        <cc-state-panel kind="unavailable" title="Issues unavailable" [message]="issues.error() || 'Issue data could not be loaded.'"></cc-state-panel>
+                      } @else if (!homeIssues().length) {
+                        <cc-state-panel kind="empty" title="No urgent issues" message="The urgent queue is clear right now."></cc-state-panel>
+                      } @else {
+                        <div class="space-y-3">
+                          @for (issue of homeIssues(); track issueKey(issue)) {
+                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                              <div class="flex items-start justify-between gap-3">
+                                <div>
+                                  <div class="text-sm font-semibold text-[var(--cc-text)]">{{ issue.title }}</div>
+                                  <div class="mt-2 text-xs leading-5 text-[var(--cc-text-soft)]">{{ issue.repo }} · #{{ issue.number }} · {{ timeAgo(issue.createdAt) }}</div>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                  <button type="button" (click)="togglePinnedIssue(issue)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ pins.isPinned('issue', issueKey(issue)) ? 'Unpin' : 'Pin' }}</button>
+                                  <button type="button" (click)="go('/issues/' + issueRoute(issue.priority))" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">View</button>
+                                </div>
+                              </div>
+                            </div>
+                          }
+                        </div>
+                      }
+                    }
+                    @case ('tasks') {
+                      @if (tasks.isLoading()) {
+                        <cc-state-panel kind="loading" title="Loading open tasks" message="Reading current open tasks for the Home dashboard."></cc-state-panel>
+                      } @else if (tasks.isUnavailable()) {
+                        <cc-state-panel kind="unavailable" title="Tasks unavailable" [message]="tasks.error() || 'Open tasks could not be loaded.'"></cc-state-panel>
+                      } @else if (!homeTasks().length) {
+                        <cc-state-panel kind="empty" title="All done" message="There are no open tasks to show here."></cc-state-panel>
+                      } @else {
+                        <div class="space-y-3">
+                          @for (task of homeTasks(); track taskKey(task)) {
+                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                              <div class="flex items-start justify-between gap-3">
+                                <div>
+                                  <div class="text-sm font-semibold text-[var(--cc-text)]">{{ task.title }}</div>
+                                  <div class="mt-2 text-xs leading-5 text-[var(--cc-text-soft)]">
+                                    {{ task.source }}
+                                    @if (task.section) { · {{ task.section }} }
+                                    @if (task.due) { · 📅 {{ task.due }} }
+                                  </div>
+                                </div>
+                                <button type="button" (click)="togglePinnedTask(task)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ pins.isPinned('task', taskKey(task)) ? 'Unpin' : 'Pin' }}</button>
+                              </div>
+                            </div>
+                          }
+                        </div>
+                      }
+                    }
+                    @case ('daily-note') {
+                      @if (notes.isLoading()) {
+                        <cc-state-panel kind="loading" title="Loading daily note" message="Reading the latest daily note for the Home dashboard."></cc-state-panel>
+                      } @else if (notes.isUnavailable()) {
+                        <cc-state-panel kind="unavailable" title="Daily note unavailable" [message]="notes.error() || 'The latest daily note could not be loaded.'"></cc-state-panel>
+                      } @else if (!notes.data()?.dailyNote) {
+                        <cc-state-panel kind="empty" title="No recent daily note" message="No recent daily note was found in the configured Obsidian paths."></cc-state-panel>
+                      } @else {
+                        <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5">
+                          <div class="flex items-center justify-between gap-4">
+                            <div class="text-sm font-semibold text-[var(--cc-text)]">{{ notes.data()!.dailyNote!.date }}</div>
+                            <cc-pill tone="info">{{ notes.data()!.dailyNote!.isToday ? 'Today' : 'Most recent' }}</cc-pill>
+                          </div>
+                          <p class="mt-4 text-sm leading-7 text-[var(--cc-text-muted)]">{{ notes.data()!.dailyNote!.preview || 'No content' }}</p>
+                        </div>
+                      }
+                    }
+                    @case ('standup') {
+                      @if (standup.isLoading()) {
+                        <cc-state-panel kind="loading" title="Loading standup" message="Reading the latest standup summary for the Home dashboard."></cc-state-panel>
+                      } @else if (standup.isUnavailable()) {
+                        <cc-state-panel kind="unavailable" title="Standup unavailable" [message]="standup.error() || 'The latest standup could not be loaded.'"></cc-state-panel>
+                      } @else if (!standup.data()) {
+                        <cc-state-panel kind="empty" title="No standup yet" message="A recent standup has not been loaded yet."></cc-state-panel>
+                      } @else {
+                        <div class="space-y-4">
+                          <div class="flex items-center justify-between gap-4">
+                            <div class="text-sm font-semibold text-[var(--cc-text)]">{{ standup.data()!.title }}</div>
+                            <cc-pill tone="info">{{ standup.data()!.isToday ? 'Today' : standup.data()!.date }}</cc-pill>
+                          </div>
+                          @for (section of standup.data()!.sections; track section.repo) {
+                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                              <div class="flex items-center justify-between gap-3">
+                                <div class="text-sm font-semibold text-[var(--cc-text)]">{{ section.repo }}</div>
+                                <div class="text-xs text-[var(--cc-text-soft)]">{{ section.stats }}</div>
+                              </div>
+                              <ul class="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-[var(--cc-text-muted)]">
+                                @for (bullet of section.bullets; track bullet) {
+                                  <li>{{ cleanedBullet(bullet) }}</li>
+                                }
+                              </ul>
+                            </div>
+                          }
+                        </div>
+                      }
+                    }
+                  }
+                </div>
+              }
+            </article>
           }
-        </cc-card>
+        }
       </section>
     </app-view-shell>
   `,
 })
 export class HomePage {
-  private readonly data = inject(DashboardDataService);
+  protected readonly data = inject(DashboardDataService);
+  protected readonly pins = inject(PinService);
+  protected readonly homeLayout = inject(HomeLayoutService);
+  protected readonly reminders = inject(RemindersService);
+  private readonly router = inject(Router);
 
   protected readonly issues = this.data.issues();
+  protected readonly prs = this.data.prs();
+  protected readonly tasks = this.data.tasks();
+  protected readonly calendar = this.data.calendar();
+  protected readonly notes = this.data.notes();
+  protected readonly standup = this.data.standup();
+  protected readonly infra = this.data.infra();
+  protected readonly repos = this.data.repos();
   protected readonly refreshingAll = this.data.refreshingAll;
 
-  protected readonly badgeLabel = computed(() => {
-    if (this.issues.isLoading()) return 'Loading';
-    if (this.issues.isRefreshing()) return 'Refreshing';
-    if (this.issues.isUnavailable()) return 'Unavailable';
+  protected readonly composerOpen = signal(false);
+  protected readonly editingReminderId = signal<string | null>(null);
+  protected readonly reminderText = signal('');
+  protected readonly reminderDue = signal<string | null>(null);
 
-    const status = this.issues.source()?.status;
-    return status === 'fresh' ? 'Connected' : status ?? 'Ready';
+  protected readonly onlineServices = computed(() => (this.infra.data() ?? []).filter((process) => process.status === 'online').length);
+  protected readonly upcomingEvents = computed(() => {
+    return (this.calendar.data() ?? [])
+      .filter((event) => new Date(event.start) > new Date())
+      .slice(0, 3);
+  });
+  protected readonly homeIssues = computed(() => {
+    const data = this.issues.data();
+    if (!data) return [] as IssueItem[];
+    const allIssues = [...data.urgent, ...data.active, ...data.deferred];
+    const pinned = allIssues.filter((issue) => this.pins.isPinned('issue', this.issueKey(issue)));
+    const recent = [...data.urgent, ...data.active]
+      .filter((issue) => !this.pins.isPinned('issue', this.issueKey(issue)))
+      .slice(0, 4);
+    return [...pinned, ...recent].slice(0, 6);
+  });
+  protected readonly homeTasks = computed(() => (this.tasks.data()?.open ?? []).slice(0, 4));
+  protected readonly hiddenSections = computed(() => this.homeLayout.layout().hidden);
+  protected readonly pinnedHomeItems = computed<PinnedHomeItem[]>(() => {
+    const items: PinnedHomeItem[] = [];
+
+    const issueData = this.issues.data();
+    if (issueData) {
+      [...issueData.urgent, ...issueData.active, ...issueData.deferred]
+        .filter((issue) => this.pins.isPinned('issue', this.issueKey(issue)))
+        .forEach((issue) => items.push({
+          type: 'Issue',
+          title: issue.title,
+          meta: `${issue.repo} · #${issue.number}`,
+          externalUrl: issue.url,
+          unpin: () => this.togglePinnedIssue(issue),
+        }));
+    }
+
+    (this.prs.data() ?? [])
+      .filter((pr) => this.pins.isPinned('pr', this.prKey(pr)))
+      .forEach((pr) => items.push({
+        type: 'PR',
+        title: pr.title,
+        meta: `${pr.repo} · #${pr.number}${pr.isDraft ? ' · Draft' : ''}`,
+        externalUrl: pr.url,
+        unpin: () => this.togglePinnedPr(pr),
+      }));
+
+    (this.tasks.data()?.open ?? [])
+      .filter((task) => this.pins.isPinned('task', this.taskKey(task)))
+      .forEach((task) => items.push({
+        type: 'Task',
+        title: task.title,
+        meta: `${task.source}${task.section ? ' · ' + task.section : ''}${task.due ? ' · 📅 ' + task.due : ''}`,
+        route: '/tasks',
+        unpin: () => this.togglePinnedTask(task),
+      }));
+
+    (this.calendar.data() ?? [])
+      .filter((event) => this.pins.isPinned('event', this.eventKey(event)))
+      .forEach((event) => items.push({
+        type: 'Event',
+        title: event.title,
+        meta: `${this.eventDateLabel(event)} · ${event.calendar}`,
+        route: '/calendar',
+        unpin: () => this.togglePinnedEvent(event),
+      }));
+
+    (this.repos.data() ?? [])
+      .filter((repo) => this.pins.isPinned('repo', repo.repoFull))
+      .forEach((repo) => items.push({
+        type: 'Repo',
+        title: repo.repo,
+        meta: `${repo.openIssues} open issues`,
+        externalUrl: `https://github.com/${repo.repoFull}/issues`,
+        unpin: () => this.togglePinnedRepo(repo),
+      }));
+
+    return items;
+  });
+  protected readonly homeMeta = computed(() => {
+    const urgent = this.issues.data()?.counts.urgent ?? 0;
+    const tasks = this.tasks.data()?.open.length ?? 0;
+    return `${urgent} urgent · ${tasks} open tasks`;
+  });
+  protected readonly tagline = computed(() => {
+    const urgent = this.issues.data()?.counts.urgent ?? 0;
+    const date = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric', timeZone: 'America/Chicago' });
+    return urgent > 0 ? `${date} · ${urgent} urgent issue${urgent === 1 ? '' : 's'} need attention` : `${date} · All clear`;
+  });
+  protected readonly layoutSummary = computed(() => {
+    const bits = [] as string[];
+    bits.push(this.homeLayout.layout().compact ? 'Compact mode is on.' : 'Standard density.');
+    if (this.homeLayout.layout().hidden.length) bits.push(`${this.homeLayout.layout().hidden.length} hidden section${this.homeLayout.layout().hidden.length === 1 ? '' : 's'}.`);
+    if (this.homeLayout.customizeMode()) bits.push('Customize mode is on.');
+    return bits.join(' ');
   });
 
-  protected readonly badgeTone = computed<'neutral' | 'success' | 'warning' | 'danger' | 'info'>(() => {
-    if (this.issues.isLoading()) return 'neutral';
-    if (this.issues.isRefreshing()) return 'info';
-    if (this.issues.isUnavailable()) return 'danger';
-
-    const status = this.issues.source()?.status;
-    if (status === 'fresh') return 'success';
-    if (status === 'stale') return 'warning';
-    if (status === 'failed') return 'danger';
-    if (status === 'refreshing') return 'info';
-    return 'neutral';
-  });
+  @HostListener('document:keydown', ['$event'])
+  protected onDocumentKeydown(event: KeyboardEvent): void {
+    const tag = (document.activeElement?.tagName || '').toLowerCase();
+    if (tag === 'input' || tag === 'textarea') return;
+    if (event.key.toLowerCase() !== 'n') return;
+    event.preventDefault();
+    this.openReminderComposer();
+  }
 
   protected refreshAll(): void {
     this.data.refreshAll();
+  }
+
+  protected go(path: string): void {
+    this.router.navigateByUrl(path);
+  }
+
+  protected sectionLabel(sectionId: string): string {
+    return {
+      pinned: 'Pinned',
+      upcoming: 'Upcoming',
+      issues: 'Recent Issues',
+      tasks: 'Open Tasks',
+      'daily-note': 'Daily Note',
+      standup: 'Latest Standup',
+    }[sectionId] || sectionId;
+  }
+
+  protected isSectionCollapsed(sectionId: string): boolean {
+    return this.homeLayout.layout().collapsed.includes(sectionId);
+  }
+
+  protected isSectionHidden(sectionId: string): boolean {
+    return this.homeLayout.layout().hidden.includes(sectionId) || (sectionId === 'pinned' && !this.homeLayout.customizeMode() && this.pinnedHomeItems().length === 0);
+  }
+
+  protected openReminderComposer(): void {
+    this.composerOpen.set(true);
+    this.editingReminderId.set(null);
+    this.reminderText.set('');
+    this.reminderDue.set(null);
+  }
+
+  protected editReminder(reminder: ReminderItem): void {
+    this.composerOpen.set(true);
+    this.editingReminderId.set(reminder.id);
+    this.reminderText.set(reminder.text);
+    this.reminderDue.set(reminder.due);
+  }
+
+  protected cancelReminderEdit(): void {
+    this.composerOpen.set(false);
+    this.editingReminderId.set(null);
+    this.reminderText.set('');
+    this.reminderDue.set(null);
+  }
+
+  protected saveReminder(): void {
+    if (this.editingReminderId()) {
+      this.reminders.update(this.editingReminderId()!, this.reminderText(), this.reminderDue());
+    } else {
+      this.reminders.add(this.reminderText(), this.reminderDue());
+    }
+    this.cancelReminderEdit();
+  }
+
+  protected completeReminder(id: string): void {
+    this.reminders.complete(id);
+  }
+
+  protected dismissReminder(id: string): void {
+    this.reminders.remove(id);
+  }
+
+  protected onReminderKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') this.saveReminder();
+    if (event.key === 'Escape') this.cancelReminderEdit();
+  }
+
+  protected togglePinnedIssue(issue: IssueItem): void {
+    this.pins.toggle('issue', this.issueKey(issue));
+  }
+
+  protected togglePinnedPr(pr: PullRequestItem): void {
+    this.pins.toggle('pr', this.prKey(pr));
+  }
+
+  protected togglePinnedTask(task: TaskItem): void {
+    this.pins.toggle('task', this.taskKey(task));
+  }
+
+  protected togglePinnedEvent(event: CalendarEvent): void {
+    this.pins.toggle('event', this.eventKey(event));
+  }
+
+  protected togglePinnedRepo(repo: RepoSummary): void {
+    this.pins.toggle('repo', repo.repoFull);
+  }
+
+  protected issueRoute(priority: string): string {
+    if (priority === 'urgent') return 'urgent';
+    if (priority === 'active') return 'active';
+    return 'backlog';
+  }
+
+  protected eventKey(event: CalendarEvent): string {
+    return encodeURIComponent((event.title + event.start).substring(0, 80));
+  }
+
+  protected eventDateLabel(event: CalendarEvent): string {
+    return new Date(event.start).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'America/Chicago' });
+  }
+
+  protected eventTimeLabel(event: CalendarEvent): string {
+    if (event.allDay) return 'All day';
+    const start = new Date(event.start);
+    return start.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'America/Chicago' });
+  }
+
+  protected cleanedBullet(bullet: string): string {
+    return bullet.replace(/\*\*/g, '').replace(/`/g, '');
+  }
+
+  protected timeAgo(iso: string): string {
+    const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+    if (!Number.isFinite(seconds)) return 'unknown';
+    if (seconds < 60) return `${seconds}s ago`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    return `${Math.floor(seconds / 86400)}d ago`;
+  }
+
+  protected issueKey(issue: IssueItem): string {
+    return `${issue.repoFull}#${issue.number}`;
+  }
+
+  protected prKey(pr: PullRequestItem): string {
+    return `${pr.repoFull}#${pr.number}`;
+  }
+
+  protected taskKey(task: TaskItem): string {
+    return encodeURIComponent(task.title).substring(0, 80);
   }
 }

--- a/frontend/src/app/features/issues/issue-list.page.ts
+++ b/frontend/src/app/features/issues/issue-list.page.ts
@@ -1,0 +1,166 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { PinService } from '../../core/state/pin.service';
+import { IssueItem } from '../../models/api';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-issue-list-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell [eyebrow]="eyebrow()" [title]="title()" [subtitle]="subtitle()" [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="info">Angular issue view</cc-pill>
+        <button
+          type="button"
+          (click)="issues.refresh()"
+          class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]"
+        >
+          Refresh
+        </button>
+        <input
+          [value]="searchText()"
+          (input)="searchText.set($any($event.target).value)"
+          class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40"
+          placeholder="Search issues…"
+        />
+      </div>
+
+      @if (issues.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading issues" message="The shared issues resource is fetching the current GitHub queue for this view."></cc-state-panel>
+      } @else if (issues.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="Issues unavailable" [message]="issues.error() || 'The issues source could not be loaded.'"></cc-state-panel>
+      } @else if (!filteredItems().length) {
+        <cc-state-panel
+          kind="empty"
+          [title]="allItems().length ? 'No issues match this filter' : 'No issues in this view'"
+          [message]="allItems().length ? 'Try a different search or clear the current filter.' : 'There are no items in this issue bucket right now.'"
+        ></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @if (pinnedItems().length) {
+            <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300">
+              <span>📌</span>
+              <span>Pinned</span>
+            </div>
+            @for (issue of pinnedItems(); track issue.repoFull + '#' + issue.number) {
+              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0">
+                    <a [href]="issue.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ issue.title }}</a>
+                    <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                      <span class="font-semibold text-amber-300">{{ issue.repo }}</span>
+                      <span>#{{ issue.number }}</span>
+                      <span>{{ timeAgo(issue.createdAt) }}</span>
+                    </div>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                      @for (label of issue.labels.slice(0, 3); track label.name) {
+                        <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 text-xs font-medium text-[var(--cc-text-muted)]">{{ label.name }}</span>
+                      }
+                    </div>
+                  </div>
+                  <div class="flex shrink-0 items-center gap-2">
+                    <button type="button" (click)="togglePinned(issue)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                    <button type="button" (click)="close(issue)" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">Close</button>
+                  </div>
+                </div>
+              </article>
+            }
+            @if (unpinnedItems().length) {
+              <div class="lg:col-span-2 2xl:col-span-3 border-t border-[var(--cc-border)]"></div>
+            }
+          }
+
+          @for (issue of unpinnedItems(); track issue.repoFull + '#' + issue.number) {
+            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0">
+                  <a [href]="issue.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ issue.title }}</a>
+                  <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                    <span class="font-semibold text-amber-300">{{ issue.repo }}</span>
+                    <span>#{{ issue.number }}</span>
+                    <span>{{ timeAgo(issue.createdAt) }}</span>
+                  </div>
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    @for (label of issue.labels.slice(0, 3); track label.name) {
+                      <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 text-xs font-medium text-[var(--cc-text-muted)]">{{ label.name }}</span>
+                    }
+                  </div>
+                </div>
+                <div class="flex shrink-0 items-center gap-2">
+                  <button type="button" (click)="togglePinned(issue)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+                  <button type="button" (click)="close(issue)" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">Close</button>
+                </div>
+              </div>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class IssueListPage {
+  private readonly route = inject(ActivatedRoute);
+  private readonly data = inject(DashboardDataService);
+  private readonly pins = inject(PinService);
+
+  protected readonly issues = this.data.issues();
+  protected readonly searchText = signal('');
+
+  protected readonly priority = this.route.snapshot.data['priority'] as 'urgent' | 'active' | 'backlog';
+  protected readonly title = computed(() => this.route.snapshot.data['title'] as string);
+  protected readonly subtitle = computed(() => this.route.snapshot.data['subtitle'] as string);
+  protected readonly eyebrow = computed(() => this.route.snapshot.data['eyebrow'] as string);
+  protected readonly meta = computed(() => {
+    const source = this.issues.source();
+    const count = this.filteredItems().length;
+    const summary = `${count} issue${count === 1 ? '' : 's'}`;
+    return source?.status ? `${summary} · ${source.status}` : summary;
+  });
+
+  protected readonly allItems = computed(() => {
+    const data = this.issues.data();
+    if (!data) return [] as IssueItem[];
+    if (this.priority === 'urgent') return data.urgent;
+    if (this.priority === 'active') return data.active;
+    return data.deferred;
+  });
+
+  protected readonly filteredItems = computed(() => {
+    const q = this.searchText().trim().toLowerCase();
+    if (!q) return this.allItems();
+    return this.allItems().filter((issue) => {
+      const labels = issue.labels.map((label) => label.name).join(' ').toLowerCase();
+      return issue.title.toLowerCase().includes(q) || issue.repo.toLowerCase().includes(q) || labels.includes(q);
+    });
+  });
+
+  protected readonly pinnedItems = computed(() => this.filteredItems().filter((issue) => this.pins.isPinned('issue', this.issueKey(issue))));
+  protected readonly unpinnedItems = computed(() => this.filteredItems().filter((issue) => !this.pins.isPinned('issue', this.issueKey(issue))));
+
+  protected togglePinned(issue: IssueItem): void {
+    this.pins.toggle('issue', this.issueKey(issue));
+  }
+
+  protected close(issue: IssueItem): void {
+    if (!window.confirm(`Close issue #${issue.number}?`)) return;
+    this.data.closeIssue(issue.repoFull, issue.number);
+  }
+
+  protected timeAgo(iso: string): string {
+    const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+    if (!Number.isFinite(seconds)) return 'unknown';
+    if (seconds < 60) return `${seconds}s ago`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    return `${Math.floor(seconds / 86400)}d ago`;
+  }
+
+  private issueKey(issue: IssueItem): string {
+    return `${issue.repoFull}#${issue.number}`;
+  }
+}

--- a/frontend/src/app/features/prs/prs.page.ts
+++ b/frontend/src/app/features/prs/prs.page.ts
@@ -1,0 +1,137 @@
+import { Component, computed, inject, signal } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { PinService } from '../../core/state/pin.service';
+import { PullRequestItem } from '../../models/api';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-prs-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Layer 1" title="Pull Requests" subtitle="Angular PR view with search, pinning, and the shared data/resource layer behind it." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="info">Angular PR view</cc-pill>
+        <button type="button" (click)="prs.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search PRs…" />
+      </div>
+
+      @if (prs.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading pull requests" message="The shared PR resource is fetching current open pull requests."></cc-state-panel>
+      } @else if (prs.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="PRs unavailable" [message]="prs.error() || 'The pull request source could not be loaded.'"></cc-state-panel>
+      } @else if (!filteredItems().length) {
+        <cc-state-panel kind="empty" [title]="allItems().length ? 'No PRs match this filter' : 'No open PRs'" [message]="allItems().length ? 'Try a different search.' : 'There are no open pull requests right now.'"></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @if (pinnedItems().length) {
+            <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
+            @for (pr of pinnedItems(); track pr.repoFull + '#' + pr.number) {
+              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0">
+                    <a [href]="pr.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ pr.title }}</a>
+                    <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                      <span class="font-semibold text-sky-300">{{ pr.repo }}</span>
+                      <span>#{{ pr.number }}</span>
+                      <span>{{ pr.headRefName }}</span>
+                      <span>{{ timeAgo(pr.createdAt) }}</span>
+                    </div>
+                    <div class="mt-3 flex flex-wrap gap-2 text-xs">
+                      @if (pr.isDraft) {
+                        <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">Draft</span>
+                      }
+                      @if (pr.reviewDecision === 'APPROVED') {
+                        <span class="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 font-medium text-emerald-200">Approved</span>
+                      }
+                      @if (pr.reviewDecision === 'CHANGES_REQUESTED') {
+                        <span class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-1 font-medium text-rose-200">Changes requested</span>
+                      }
+                    </div>
+                  </div>
+                  <button type="button" (click)="togglePinned(pr)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                </div>
+              </article>
+            }
+            @if (unpinnedItems().length) {
+              <div class="lg:col-span-2 2xl:col-span-3 border-t border-[var(--cc-border)]"></div>
+            }
+          }
+
+          @for (pr of unpinnedItems(); track pr.repoFull + '#' + pr.number) {
+            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0">
+                  <a [href]="pr.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ pr.title }}</a>
+                  <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                    <span class="font-semibold text-sky-300">{{ pr.repo }}</span>
+                    <span>#{{ pr.number }}</span>
+                    <span>{{ pr.headRefName }}</span>
+                    <span>{{ timeAgo(pr.createdAt) }}</span>
+                  </div>
+                  <div class="mt-3 flex flex-wrap gap-2 text-xs">
+                    @if (pr.isDraft) {
+                      <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">Draft</span>
+                    }
+                    @if (pr.reviewDecision === 'APPROVED') {
+                      <span class="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 font-medium text-emerald-200">Approved</span>
+                    }
+                    @if (pr.reviewDecision === 'CHANGES_REQUESTED') {
+                      <span class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-1 font-medium text-rose-200">Changes requested</span>
+                    }
+                  </div>
+                </div>
+                <button type="button" (click)="togglePinned(pr)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+              </div>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class PrsPage {
+  private readonly data = inject(DashboardDataService);
+  private readonly pins = inject(PinService);
+
+  protected readonly prs = this.data.prs();
+  protected readonly searchText = signal('');
+
+  protected readonly allItems = computed(() => this.prs.data() ?? []);
+  protected readonly filteredItems = computed(() => {
+    const q = this.searchText().trim().toLowerCase();
+    if (!q) return this.allItems();
+    return this.allItems().filter((pr) => {
+      const author = pr.author?.login?.toLowerCase() || '';
+      return pr.title.toLowerCase().includes(q) || pr.repo.toLowerCase().includes(q) || pr.headRefName.toLowerCase().includes(q) || author.includes(q);
+    });
+  });
+  protected readonly pinnedItems = computed(() => this.filteredItems().filter((pr) => this.pins.isPinned('pr', this.prKey(pr))));
+  protected readonly unpinnedItems = computed(() => this.filteredItems().filter((pr) => !this.pins.isPinned('pr', this.prKey(pr))));
+  protected readonly meta = computed(() => {
+    const source = this.prs.source();
+    const count = this.filteredItems().length;
+    const drafts = this.allItems().filter((pr) => pr.isDraft).length;
+    const summary = `${count} open PR${count === 1 ? '' : 's'} · ${drafts} draft${drafts === 1 ? '' : 's'}`;
+    return source?.status ? `${summary} · ${source.status}` : summary;
+  });
+
+  protected togglePinned(pr: PullRequestItem): void {
+    this.pins.toggle('pr', this.prKey(pr));
+  }
+
+  protected timeAgo(iso: string): string {
+    const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+    if (!Number.isFinite(seconds)) return 'unknown';
+    if (seconds < 60) return `${seconds}s ago`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    return `${Math.floor(seconds / 86400)}d ago`;
+  }
+
+  private prKey(pr: PullRequestItem): string {
+    return `${pr.repoFull}#${pr.number}`;
+  }
+}

--- a/frontend/src/app/features/tasks/done.page.ts
+++ b/frontend/src/app/features/tasks/done.page.ts
@@ -1,0 +1,71 @@
+import { Component, computed, inject, signal } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-done-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Layer 1" title="Completed Tasks" subtitle="Angular done view for recently completed Obsidian tasks." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="info">Angular done view</cc-pill>
+        <button type="button" (click)="tasks.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search completed tasks…" />
+      </div>
+
+      @if (tasks.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading completed tasks" message="The shared tasks resource is loading the completed task history."></cc-state-panel>
+      } @else if (tasks.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="Completed tasks unavailable" [message]="tasks.error() || 'The tasks source could not be loaded.'"></cc-state-panel>
+      } @else if (!filteredItems().length) {
+        <cc-state-panel kind="empty" [title]="allItems().length ? 'No completed tasks match this filter' : 'No completed tasks yet'" [message]="allItems().length ? 'Try a different search.' : 'Completed tasks will appear here once work gets finished.'"></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @for (task of filteredItems(); track taskKey(task)) {
+            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <div class="text-base font-semibold leading-6 text-[var(--cc-text)]">{{ task.title }}</div>
+              <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">{{ task.source }}</span>
+                @if (task.section) {
+                  <span>{{ task.section }}</span>
+                }
+                @if (task.recurring) {
+                  <span>🔁 recurring</span>
+                }
+                <span class="text-emerald-300">✓ {{ task.completedAt || 'completed' }}</span>
+              </div>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class DonePage {
+  private readonly data = inject(DashboardDataService);
+
+  protected readonly tasks = this.data.tasks();
+  protected readonly searchText = signal('');
+  protected readonly allItems = computed(() => this.tasks.data()?.completed ?? []);
+  protected readonly filteredItems = computed(() => {
+    const q = this.searchText().trim().toLowerCase();
+    if (!q) return this.allItems();
+    return this.allItems().filter((task) => {
+      return task.title.toLowerCase().includes(q)
+        || task.source.toLowerCase().includes(q)
+        || (task.section || '').toLowerCase().includes(q);
+    });
+  });
+  protected readonly meta = computed(() => {
+    const source = this.tasks.source();
+    const summary = `${this.filteredItems().length} completed task${this.filteredItems().length === 1 ? '' : 's'}`;
+    return source?.status ? `${summary} · ${source.status}` : summary;
+  });
+
+  protected taskKey(task: { title: string }): string {
+    return encodeURIComponent(task.title).substring(0, 80);
+  }
+}

--- a/frontend/src/app/features/tasks/tasks.page.ts
+++ b/frontend/src/app/features/tasks/tasks.page.ts
@@ -1,0 +1,118 @@
+import { Component, computed, inject, signal } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { PinService } from '../../core/state/pin.service';
+import { TaskItem } from '../../models/api';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-tasks-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Layer 1" title="Tasks" subtitle="Angular task view with search, pinning, and shared Obsidian-backed task data." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="info">Angular task view</cc-pill>
+        <button type="button" (click)="tasks.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search tasks…" />
+      </div>
+
+      @if (tasks.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading tasks" message="The shared tasks resource is reading current open tasks from Obsidian."></cc-state-panel>
+      } @else if (tasks.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="Tasks unavailable" [message]="tasks.error() || 'The tasks source could not be loaded.'"></cc-state-panel>
+      } @else if (!filteredItems().length) {
+        <cc-state-panel kind="empty" [title]="allItems().length ? 'No tasks match this filter' : 'All done'" [message]="allItems().length ? 'Try a different search.' : 'There are no open tasks right now.'"></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @if (pinnedItems().length) {
+            <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
+            @for (task of pinnedItems(); track taskKey(task)) {
+              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0">
+                    <div class="text-base font-semibold leading-6 text-[var(--cc-text)]">{{ task.title }}</div>
+                    <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                      <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">{{ task.source }}</span>
+                      @if (task.section) {
+                        <span>{{ task.section }}</span>
+                      }
+                      @if (task.recurring) {
+                        <span>🔁 recurring</span>
+                      }
+                      @if (task.due) {
+                        <span class="text-rose-300">📅 {{ task.due }}</span>
+                      }
+                    </div>
+                  </div>
+                  <button type="button" (click)="togglePinned(task)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                </div>
+              </article>
+            }
+            @if (unpinnedItems().length) {
+              <div class="lg:col-span-2 2xl:col-span-3 border-t border-[var(--cc-border)]"></div>
+            }
+          }
+
+          @for (task of unpinnedItems(); track taskKey(task)) {
+            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0">
+                  <div class="text-base font-semibold leading-6 text-[var(--cc-text)]">{{ task.title }}</div>
+                  <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                    <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">{{ task.source }}</span>
+                    @if (task.section) {
+                      <span>{{ task.section }}</span>
+                    }
+                    @if (task.recurring) {
+                      <span>🔁 recurring</span>
+                    }
+                    @if (task.due) {
+                      <span class="text-rose-300">📅 {{ task.due }}</span>
+                    }
+                  </div>
+                </div>
+                <button type="button" (click)="togglePinned(task)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+              </div>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class TasksPage {
+  private readonly data = inject(DashboardDataService);
+  private readonly pins = inject(PinService);
+
+  protected readonly tasks = this.data.tasks();
+  protected readonly searchText = signal('');
+  protected readonly allItems = computed(() => this.tasks.data()?.open ?? []);
+  protected readonly filteredItems = computed(() => {
+    const q = this.searchText().trim().toLowerCase();
+    if (!q) return this.allItems();
+    return this.allItems().filter((task) => {
+      return task.title.toLowerCase().includes(q)
+        || task.source.toLowerCase().includes(q)
+        || (task.section || '').toLowerCase().includes(q);
+    });
+  });
+  protected readonly pinnedItems = computed(() => this.filteredItems().filter((task) => this.pins.isPinned('task', this.taskKey(task))));
+  protected readonly unpinnedItems = computed(() => this.filteredItems().filter((task) => !this.pins.isPinned('task', this.taskKey(task))));
+  protected readonly meta = computed(() => {
+    const source = this.tasks.source();
+    const open = this.tasks.data()?.open.length ?? 0;
+    const done = this.tasks.data()?.completed.length ?? 0;
+    const summary = `${open} open · ${done} done`;
+    return source?.status ? `${summary} · ${source.status}` : summary;
+  });
+
+  protected togglePinned(task: TaskItem): void {
+    this.pins.toggle('task', this.taskKey(task));
+  }
+
+  protected taskKey(task: TaskItem): string {
+    return encodeURIComponent(task.title).substring(0, 80);
+  }
+}

--- a/frontend/src/app/layout/app-shell.component.ts
+++ b/frontend/src/app/layout/app-shell.component.ts
@@ -15,15 +15,15 @@ import { ThemeToggleComponent } from './theme-toggle.component';
           <div class="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
             <div>
               <p class="text-xs font-semibold uppercase tracking-[0.35em] text-[var(--cc-text-soft)]">command.center rewrite</p>
-              <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">Shared Angular shell and UI primitives</h1>
+              <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">Angular daily-use views are live</h1>
               <p class="mt-3 max-w-3xl text-sm leading-7 text-[var(--cc-text-muted)]">
-                Angular now has a reusable dashboard frame, theme support, and shared components so the real view migration can happen without duplicating markup.
+                The rewrite now includes real Angular versions of Home, Issues, PRs, Tasks, and Done, backed by the shared shell, data layer, and interaction state services.
               </p>
             </div>
 
             <div class="flex flex-wrap items-center gap-3">
-              <cc-pill tone="accent">Issue #69</cc-pill>
-              <cc-pill>Shell • Theme • Primitives</cc-pill>
+              <cc-pill tone="accent">Issue #71</cc-pill>
+              <cc-pill>Daily-use Angular views</cc-pill>
               <app-theme-toggle></app-theme-toggle>
             </div>
           </div>

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -73,13 +73,33 @@ export interface IssuesViewModel {
   updatedAt: number | null;
 }
 
+export interface RepoSummary {
+  repo: string;
+  repoFull: string;
+  openIssues: number;
+  bugs: number;
+  enhancements: number;
+  lastActivity: string | null;
+  tracked: boolean;
+  archived: boolean;
+}
+
 export interface ReposResponse extends ApiEnvelope {
-  repos: unknown[];
+  repos: RepoSummary[];
   updatedAt: number | null;
 }
 
+export interface CalendarEvent {
+  title: string;
+  start: string;
+  end: string;
+  allDay: boolean;
+  calendar: string;
+  location?: string | null;
+}
+
 export interface CalendarResponse extends ApiEnvelope {
-  events: unknown[];
+  events: CalendarEvent[];
   updatedAt: number | null;
 }
 
@@ -99,19 +119,59 @@ export interface InfraResponse extends ApiEnvelope {
   updatedAt: number | null;
 }
 
+export interface TaskItem {
+  title: string;
+  source: string;
+  section?: string | null;
+  recurring?: boolean;
+  due?: string | null;
+  color: string;
+  completedAt?: string | null;
+}
+
 export interface TasksResponse extends ApiEnvelope {
-  tasks: unknown[];
-  completedTasks: unknown[];
+  tasks: TaskItem[];
+  completedTasks: TaskItem[];
   updatedAt: number | null;
+}
+
+export interface PullRequestAuthor {
+  login?: string;
+}
+
+export interface PullRequestItem {
+  number: number;
+  title: string;
+  url: string;
+  repo: string;
+  repoFull: string;
+  headRefName: string;
+  author?: PullRequestAuthor | null;
+  createdAt: string;
+  isDraft: boolean;
+  reviewDecision?: string | null;
 }
 
 export interface PrsResponse extends ApiEnvelope {
-  prs: unknown[];
+  prs: PullRequestItem[];
   updatedAt: number | null;
 }
 
+export interface StandupSection {
+  repo: string;
+  stats: string;
+  bullets: string[];
+}
+
+export interface StandupSummary {
+  title: string;
+  date: string;
+  isToday: boolean;
+  sections: StandupSection[];
+}
+
 export interface StandupResponse extends ApiEnvelope {
-  standup: unknown | null;
+  standup: StandupSummary | null;
   updatedAt: number | null;
 }
 
@@ -122,11 +182,29 @@ export interface AnalyticsResponse extends ApiEnvelope {
   updatedAt: string | null;
 }
 
+export interface DailyNote {
+  date: string;
+  isToday: boolean;
+  preview: string;
+}
+
+export interface DecisionNote {
+  title: string;
+  date: string;
+  status?: string | null;
+  preview: string;
+}
+
 export interface NotesResponse extends ApiEnvelope {
-  daily: unknown;
-  decisions: unknown[];
+  dailyNote: DailyNote | null;
+  decisions: DecisionNote[];
 }
 
 export interface RefreshResponse {
   ok: boolean;
+}
+
+export interface CloseIssueResponse {
+  ok: boolean;
+  error?: string;
 }


### PR DESCRIPTION
## Summary
- migrate the daily-use Angular views for issues, PRs, tasks, and done with shared pinning and search/filter behavior
- migrate the Home dashboard onto Angular with reminders, pinned items, upcoming events, recent issues, open tasks, daily note, standup, and layout controls
- wire the migrated views into real Angular routes and the shared shell/data layer from the prior issues

## Testing
- npm --prefix frontend run build
- curl -I http://127.0.0.1:4200
- curl -s http://127.0.0.1:4200/main.js | grep -o 'Angular daily-use views are live'

Closes #71.
