### PR TITLE
Migrate remaining Angular secondary views

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,9 +1,13 @@
 import { Routes } from '@angular/router';
 
+import { AnalyticsPage } from './features/analytics/analytics.page';
+import { CalendarPage } from './features/calendar/calendar.page';
 import { HomePage } from './features/home/home.page';
+import { InfraPage } from './features/infra/infra.page';
 import { IssueListPage } from './features/issues/issue-list.page';
+import { NotesPage } from './features/notes/notes.page';
 import { PrsPage } from './features/prs/prs.page';
-import { PlaceholderPageComponent } from './features/shared/placeholder-page.component';
+import { ReposPage } from './features/repos/repos.page';
 import { DonePage } from './features/tasks/done.page';
 import { TasksPage } from './features/tasks/tasks.page';
 
@@ -62,40 +66,29 @@ export const routes: Routes = [
     title: 'Completed Tasks',
   },
   {
+    path: 'notes',
+    component: NotesPage,
+    title: 'Notes',
+  },
+  {
     path: 'calendar',
-    component: PlaceholderPageComponent,
-    title: 'Calendar Migration Target',
-    data: {
-      title: 'Calendar migration target',
-      description: 'The dedicated Calendar page is still part of issue #72, but the Home dashboard already consumes calendar data through the shared resource layer.',
-    },
+    component: CalendarPage,
+    title: 'Calendar',
   },
   {
     path: 'repos',
-    component: PlaceholderPageComponent,
-    title: 'Repos Migration Target',
-    data: {
-      title: 'Repository migration target',
-      description: 'The dedicated Repositories page remains in issue #72. Home can still surface repo summaries and pinned repo items in the meantime.',
-    },
+    component: ReposPage,
+    title: 'Repositories',
   },
   {
     path: 'infra',
-    component: PlaceholderPageComponent,
-    title: 'Infra Migration Target',
-    data: {
-      title: 'Infrastructure migration target',
-      description: 'The dedicated Infrastructure page remains in issue #72, but Home can already show a lightweight infra summary from the shared resource layer.',
-    },
+    component: InfraPage,
+    title: 'Infrastructure',
   },
   {
-    path: 'notes',
-    component: PlaceholderPageComponent,
-    title: 'Notes Migration Target',
-    data: {
-      title: 'Notes migration target',
-      description: 'The dedicated Notes view remains part of issue #72, while Home already uses the shared notes and standup resources.',
-    },
+    path: 'analytics',
+    component: AnalyticsPage,
+    title: 'Analytics',
   },
   {
     path: '**',

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -17,10 +17,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render the Angular daily-views heading', async () => {
+  it('should render the full Angular dashboard heading', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Angular daily-use views are live');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Angular now covers the full dashboard');
   });
 });

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -18,6 +18,10 @@ export class App {
     { path: '/prs', label: 'PRs' },
     { path: '/tasks', label: 'Tasks' },
     { path: '/done', label: 'Done' },
-    { path: '/notes', label: 'Next up' },
+    { path: '/notes', label: 'Notes' },
+    { path: '/calendar', label: 'Calendar' },
+    { path: '/repos', label: 'Repos' },
+    { path: '/infra', label: 'Infra' },
+    { path: '/analytics', label: 'Analytics' },
   ];
 }

--- a/frontend/src/app/features/analytics/analytics.page.ts
+++ b/frontend/src/app/features/analytics/analytics.page.ts
@@ -1,0 +1,102 @@
+import { Component, computed, inject } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-analytics-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Pass 2" title="Analytics" subtitle="Angular analytics view with shared resource loading, summary metrics, and site table presentation." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="warning">Angular secondary view</cc-pill>
+        <button type="button" (click)="analytics.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+      </div>
+
+      @if (analytics.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading analytics" message="Reading the latest analytics snapshot from Umami through the shared analytics resource."></cc-state-panel>
+      } @else if (analytics.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="Analytics unavailable" [message]="analytics.error() || 'Analytics data could not be loaded.'"></cc-state-panel>
+      } @else if (!analytics.data()?.sites?.length) {
+        <cc-state-panel kind="empty" title="No analytics data" message="No analytics site rows were returned for the current range."></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 md:grid-cols-4">
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Page Views</div><div class="mt-3 text-3xl font-semibold text-amber-300">{{ analytics.data()!.totals.pageviews.toLocaleString() }}</div></div>
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Unique Visitors</div><div class="mt-3 text-3xl font-semibold text-sky-300">{{ analytics.data()!.totals.visitors.toLocaleString() }}</div></div>
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Sessions</div><div class="mt-3 text-3xl font-semibold text-emerald-300">{{ analytics.data()!.totals.visits.toLocaleString() }}</div></div>
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Avg Bounce</div><div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ averageBounce() }}%</div></div>
+        </section>
+
+        <section class="overflow-hidden rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)]">
+          <div class="overflow-x-auto">
+            <table class="min-w-full border-collapse text-sm">
+              <thead>
+                <tr class="border-b border-[var(--cc-border)] text-left text-[var(--cc-text-soft)]">
+                  <th class="px-5 py-4 font-semibold">Property</th>
+                  <th class="px-5 py-4 text-right font-semibold">Page Views</th>
+                  <th class="px-5 py-4 text-right font-semibold">Visitors</th>
+                  <th class="px-5 py-4 text-right font-semibold">Sessions</th>
+                  <th class="px-5 py-4 text-right font-semibold">Bounce</th>
+                  <th class="px-5 py-4 text-right font-semibold">Avg Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (site of analytics.data()!.sites; track site.domain) {
+                  <tr class="border-b border-[var(--cc-border)] align-top">
+                    <td class="px-5 py-4">
+                      <div class="font-semibold text-[var(--cc-text)]">{{ site.name }}</div>
+                      <a [href]="'https://' + site.domain" target="_blank" class="mt-1 inline-flex text-xs text-[var(--cc-text-soft)]">{{ site.domain }}</a>
+                      <div class="mt-3 h-1.5 w-28 overflow-hidden rounded-full bg-[var(--cc-surface-muted)]">
+                        <div class="h-full rounded-full bg-amber-300" [style.width.%]="shareOfPageviews(site.pageviews)"></div>
+                      </div>
+                    </td>
+                    <td class="px-5 py-4 text-right font-semibold text-amber-300">{{ site.pageviews.toLocaleString() }}</td>
+                    <td class="px-5 py-4 text-right text-sky-300">{{ site.visitors.toLocaleString() }}</td>
+                    <td class="px-5 py-4 text-right text-[var(--cc-text)]">{{ site.visits.toLocaleString() }}</td>
+                    <td class="px-5 py-4 text-right" [class.text-rose-300]="siteBounce(site) > 70" [class.text-amber-300]="siteBounce(site) > 50 && siteBounce(site) <= 70" [class.text-emerald-300]="siteBounce(site) <= 50">{{ siteBounce(site) }}%</td>
+                    <td class="px-5 py-4 text-right text-[var(--cc-text-soft)]">{{ averageDuration(site.totaltime, site.visits) }}</td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class AnalyticsPage {
+  private readonly data = inject(DashboardDataService);
+
+  protected readonly analytics = this.data.analytics();
+  protected readonly averageBounce = computed(() => {
+    const totals = this.analytics.data()?.totals;
+    if (!totals || totals.visits === 0) return 0;
+    return Math.round((totals.bounces / totals.visits) * 100);
+  });
+  protected readonly meta = computed(() => {
+    const count = this.analytics.data()?.sites.length ?? 0;
+    const summary = `Last 30 days · ${count} properties`;
+    return this.analytics.source()?.status ? `${summary} · ${this.analytics.source()!.status}` : summary;
+  });
+
+  protected shareOfPageviews(pageviews: number): number {
+    const total = this.analytics.data()?.totals.pageviews ?? 0;
+    if (!total) return 0;
+    return Math.round((pageviews / total) * 100);
+  }
+
+  protected siteBounce(site: { bounces: number; visits: number }): number {
+    if (!site.visits) return 0;
+    return Math.round((site.bounces / site.visits) * 100);
+  }
+
+  protected averageDuration(totalTime: number, visits: number): string {
+    if (!visits) return '0s';
+    const seconds = Math.round(totalTime / visits);
+    if (seconds >= 60) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+    return `${seconds}s`;
+  }
+}

--- a/frontend/src/app/features/calendar/calendar.page.ts
+++ b/frontend/src/app/features/calendar/calendar.page.ts
@@ -1,0 +1,103 @@
+import { Component, computed, inject } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { PinService } from '../../core/state/pin.service';
+import { CalendarEvent } from '../../models/api';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-calendar-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Pass 1" title="Calendar" subtitle="Upcoming events now run through Angular with shared event cards and pinning." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="info">Angular secondary view</cc-pill>
+        <button type="button" (click)="calendar.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+      </div>
+
+      @if (calendar.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading events" message="Reading the current upcoming event window from the shared calendar resource."></cc-state-panel>
+      } @else if (calendar.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="Calendar unavailable" [message]="calendar.error() || 'Calendar events could not be loaded.'"></cc-state-panel>
+      } @else if (!calendar.data()?.length) {
+        <cc-state-panel kind="empty" title="No upcoming events" message="Nothing is scheduled in the next window."></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @if (pinnedItems().length) {
+            <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
+            @for (event of pinnedItems(); track eventKey(event)) {
+              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <div class="text-base font-semibold text-[var(--cc-text)]">{{ event.title }}</div>
+                    <div class="mt-3 text-xs leading-6 text-[var(--cc-text-soft)]">{{ eventDateLabel(event) }} · {{ eventTimeLabel(event) }} · {{ event.calendar }}</div>
+                    @if (event.location) {
+                      <div class="mt-2 text-xs text-[var(--cc-text-soft)]">📍 {{ event.location }}</div>
+                    }
+                  </div>
+                  <button type="button" (click)="togglePinned(event)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                </div>
+              </article>
+            }
+            @if (unpinnedItems().length) {
+              <div class="lg:col-span-2 2xl:col-span-3 border-t border-[var(--cc-border)]"></div>
+            }
+          }
+
+          @for (event of unpinnedItems(); track eventKey(event)) {
+            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm" [class.opacity-60]="isPast(event)">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <div class="text-base font-semibold text-[var(--cc-text)]">{{ event.title }}</div>
+                  <div class="mt-3 text-xs leading-6 text-[var(--cc-text-soft)]">{{ eventDateLabel(event) }} · {{ eventTimeLabel(event) }} · {{ event.calendar }}</div>
+                  @if (event.location) {
+                    <div class="mt-2 text-xs text-[var(--cc-text-soft)]">📍 {{ event.location }}</div>
+                  }
+                </div>
+                <button type="button" (click)="togglePinned(event)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+              </div>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class CalendarPage {
+  private readonly data = inject(DashboardDataService);
+  protected readonly pins = inject(PinService);
+
+  protected readonly calendar = this.data.calendar();
+  protected readonly allItems = computed(() => this.calendar.data() ?? []);
+  protected readonly pinnedItems = computed(() => this.allItems().filter((event) => this.pins.isPinned('event', this.eventKey(event))));
+  protected readonly unpinnedItems = computed(() => this.allItems().filter((event) => !this.pins.isPinned('event', this.eventKey(event))));
+  protected readonly meta = computed(() => `${this.allItems().length} upcoming event${this.allItems().length === 1 ? '' : 's'}${this.calendar.source()?.status ? ` · ${this.calendar.source()!.status}` : ''}`);
+
+  protected togglePinned(event: CalendarEvent): void {
+    this.pins.toggle('event', this.eventKey(event));
+  }
+
+  protected eventKey(event: CalendarEvent): string {
+    return encodeURIComponent((event.title + event.start).substring(0, 80));
+  }
+
+  protected eventDateLabel(event: CalendarEvent): string {
+    const start = new Date(event.start);
+    const today = new Date();
+    if (start.toDateString() === today.toDateString()) return 'Today';
+    return start.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'America/Chicago' });
+  }
+
+  protected eventTimeLabel(event: CalendarEvent): string {
+    if (event.allDay) return 'All day';
+    const start = new Date(event.start);
+    const end = new Date(event.end);
+    return `${start.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'America/Chicago' })} – ${end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'America/Chicago' })}`;
+  }
+
+  protected isPast(event: CalendarEvent): boolean {
+    return new Date(event.end) < new Date();
+  }
+}

--- a/frontend/src/app/features/infra/infra.page.ts
+++ b/frontend/src/app/features/infra/infra.page.ts
@@ -1,0 +1,82 @@
+import { Component, computed, inject } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-infra-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Pass 2" title="Infrastructure" subtitle="Angular Infra view with summary stats, process cards, and degraded-state handling." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="warning">Angular secondary view</cc-pill>
+        <button type="button" (click)="infra.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+      </div>
+
+      @if (infra.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading infrastructure" message="Reading PM2 process status and runtime metrics for the Infra view."></cc-state-panel>
+      } @else if (infra.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="Process monitoring unavailable" [message]="infra.error() || 'The rest of command-center is still working, but the Infra source failed.'"></cc-state-panel>
+      } @else if (!infra.data()?.length) {
+        <cc-state-panel kind="empty" title="No process data" message="No infrastructure processes were returned for the current environment."></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 md:grid-cols-4">
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Total</div><div class="mt-3 text-3xl font-semibold text-[var(--cc-text)]">{{ infra.data()!.length }}</div></div>
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Online</div><div class="mt-3 text-3xl font-semibold text-emerald-300">{{ onlineCount() }}</div></div>
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Down</div><div class="mt-3 text-3xl font-semibold text-rose-300">{{ downCount() }}</div></div>
+          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Restarts</div><div class="mt-3 text-3xl font-semibold text-amber-300">{{ restartCount() }}</div></div>
+        </section>
+
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @for (process of infra.data()!; track process.name + ':' + process.id) {
+            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <div class="text-base font-semibold text-[var(--cc-text)]">{{ process.name }}</div>
+                  <div class="mt-2 text-xs text-[var(--cc-text-soft)]">#{{ process.id }} · PID {{ process.pid || '—' }}</div>
+                </div>
+                <cc-pill [tone]="process.status === 'online' ? 'success' : process.status === 'erroring' ? 'danger' : 'warning'">{{ process.status }}</cc-pill>
+              </div>
+
+              <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
+                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Uptime</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatUptime(process.uptime) }}</div></div>
+                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Memory</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatMemory(process.memory) }}</div></div>
+                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Restarts</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ process.restarts }}</div></div>
+              </div>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class InfraPage {
+  private readonly data = inject(DashboardDataService);
+
+  protected readonly infra = this.data.infra();
+  protected readonly onlineCount = computed(() => (this.infra.data() ?? []).filter((process) => process.status === 'online').length);
+  protected readonly downCount = computed(() => (this.infra.data() ?? []).filter((process) => process.status !== 'online').length);
+  protected readonly restartCount = computed(() => (this.infra.data() ?? []).reduce((sum, process) => sum + (process.restarts || 0), 0));
+  protected readonly meta = computed(() => {
+    const summary = `${this.onlineCount()} online · ${this.downCount()} down · ${this.restartCount()} restarts`;
+    return this.infra.source()?.status ? `${summary} · ${this.infra.source()!.status}` : summary;
+  });
+
+  protected formatUptime(ms: number | null): string {
+    if (!ms) return '—';
+    const seconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+    if (days > 0) return `${days}d ${hours % 24}h`;
+    if (hours > 0) return `${hours}h ${minutes % 60}m`;
+    if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
+    return `${seconds}s`;
+  }
+
+  protected formatMemory(bytes: number): string {
+    return bytes ? `${(bytes / 1024 / 1024).toFixed(1)} MB` : '0 MB';
+  }
+}

--- a/frontend/src/app/features/issues/issue-list.page.ts
+++ b/frontend/src/app/features/issues/issue-list.page.ts
@@ -110,6 +110,7 @@ export class IssueListPage {
 
   protected readonly issues = this.data.issues();
   protected readonly searchText = signal('');
+  protected readonly repoFilter = signal<string | null>(this.route.snapshot.queryParamMap.get('repo'));
 
   protected readonly priority = this.route.snapshot.data['priority'] as 'urgent' | 'active' | 'backlog';
   protected readonly title = computed(() => this.route.snapshot.data['title'] as string);
@@ -118,7 +119,8 @@ export class IssueListPage {
   protected readonly meta = computed(() => {
     const source = this.issues.source();
     const count = this.filteredItems().length;
-    const summary = `${count} issue${count === 1 ? '' : 's'}`;
+    const repo = this.repoFilter();
+    const summary = `${count} issue${count === 1 ? '' : 's'}${repo ? ` · ${repo}` : ''}`;
     return source?.status ? `${summary} · ${source.status}` : summary;
   });
 
@@ -132,15 +134,23 @@ export class IssueListPage {
 
   protected readonly filteredItems = computed(() => {
     const q = this.searchText().trim().toLowerCase();
-    if (!q) return this.allItems();
+    const repo = this.repoFilter()?.toLowerCase() || null;
     return this.allItems().filter((issue) => {
       const labels = issue.labels.map((label) => label.name).join(' ').toLowerCase();
-      return issue.title.toLowerCase().includes(q) || issue.repo.toLowerCase().includes(q) || labels.includes(q);
+      const matchesRepo = !repo || issue.repo.toLowerCase() === repo;
+      const matchesText = !q || issue.title.toLowerCase().includes(q) || issue.repo.toLowerCase().includes(q) || labels.includes(q);
+      return matchesRepo && matchesText;
     });
   });
 
   protected readonly pinnedItems = computed(() => this.filteredItems().filter((issue) => this.pins.isPinned('issue', this.issueKey(issue))));
   protected readonly unpinnedItems = computed(() => this.filteredItems().filter((issue) => !this.pins.isPinned('issue', this.issueKey(issue))));
+
+  constructor() {
+    this.route.queryParamMap.subscribe((params) => {
+      this.repoFilter.set(params.get('repo'));
+    });
+  }
 
   protected togglePinned(issue: IssueItem): void {
     this.pins.toggle('issue', this.issueKey(issue));

--- a/frontend/src/app/features/notes/notes.page.ts
+++ b/frontend/src/app/features/notes/notes.page.ts
@@ -1,0 +1,127 @@
+import { Component, computed, inject } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-notes-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Pass 1" title="Notes" subtitle="Daily note, decision log, and latest standup presentation now run from Angular." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="info">Angular secondary view</cc-pill>
+        <button type="button" (click)="refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+      </div>
+
+      <section class="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <article class="space-y-6">
+          <section class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-6 md:p-7">
+            <div class="flex items-center justify-between gap-4">
+              <div class="text-lg font-semibold tracking-tight text-[var(--cc-text)]">Latest Standup</div>
+              <cc-pill tone="info">{{ standup.data()?.isToday ? 'Today' : (standup.data()?.date || 'Recent') }}</cc-pill>
+            </div>
+            <div class="mt-5">
+              @if (standup.isLoading()) {
+                <cc-state-panel kind="loading" title="Loading standup" message="Reading the latest standup summary from the shared notes resource layer."></cc-state-panel>
+              } @else if (standup.isUnavailable()) {
+                <cc-state-panel kind="unavailable" title="Standup unavailable" [message]="standup.error() || 'The latest standup could not be loaded.'"></cc-state-panel>
+              } @else if (!standup.data()) {
+                <cc-state-panel kind="empty" title="No standup yet" message="A recent standup has not been loaded yet."></cc-state-panel>
+              } @else {
+                <div class="space-y-4">
+                  <div class="text-sm text-[var(--cc-text-muted)]">{{ standup.data()!.title }}</div>
+                  @for (section of standup.data()!.sections; track section.repo) {
+                    <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                      <div class="flex items-center justify-between gap-4">
+                        <div class="text-sm font-semibold text-[var(--cc-text)]">{{ section.repo }}</div>
+                        <div class="text-xs text-[var(--cc-text-soft)]">{{ section.stats }}</div>
+                      </div>
+                      <ul class="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-[var(--cc-text-muted)]">
+                        @for (bullet of section.bullets; track bullet) {
+                          <li>{{ cleanedBullet(bullet) }}</li>
+                        }
+                      </ul>
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+          </section>
+        </article>
+
+        <article class="space-y-6">
+          <section class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-6 md:p-7">
+            <div class="text-lg font-semibold tracking-tight text-[var(--cc-text)]">Daily Note</div>
+            <div class="mt-5">
+              @if (notes.isLoading()) {
+                <cc-state-panel kind="loading" title="Loading daily note" message="Reading the most recent daily note from the configured notes paths."></cc-state-panel>
+              } @else if (notes.isUnavailable()) {
+                <cc-state-panel kind="unavailable" title="Notes unavailable" [message]="notes.error() || 'Daily note data could not be loaded.'"></cc-state-panel>
+              } @else if (!notes.data()?.dailyNote) {
+                <cc-state-panel kind="empty" title="No recent daily note" message="No recent daily note was found in the configured Obsidian paths."></cc-state-panel>
+              } @else {
+                <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5">
+                  <div class="flex items-center justify-between gap-4">
+                    <div class="text-sm font-semibold text-[var(--cc-text)]">{{ notes.data()!.dailyNote!.date }}</div>
+                    <cc-pill tone="info">{{ notes.data()!.dailyNote!.isToday ? 'Today' : 'Most recent' }}</cc-pill>
+                  </div>
+                  <p class="mt-4 text-sm leading-7 text-[var(--cc-text-muted)]">{{ notes.data()!.dailyNote!.preview || 'No content' }}</p>
+                </div>
+              }
+            </div>
+          </section>
+
+          <section class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-6 md:p-7">
+            <div class="text-lg font-semibold tracking-tight text-[var(--cc-text)]">Recent Decisions</div>
+            <div class="mt-5">
+              @if (notes.isLoading()) {
+                <cc-state-panel kind="loading" title="Loading decisions" message="Reading the latest decision notes from the shared notes resource."></cc-state-panel>
+              } @else if (notes.isUnavailable()) {
+                <cc-state-panel kind="unavailable" title="Decisions unavailable" [message]="notes.error() || 'Decision notes could not be loaded.'"></cc-state-panel>
+              } @else if (!notes.data()?.decisions?.length) {
+                <cc-state-panel kind="empty" title="No recent decisions" message="Recent decision notes will appear here once they are available."></cc-state-panel>
+              } @else {
+                <div class="space-y-3">
+                  @for (decision of notes.data()!.decisions; track decision.title + decision.date) {
+                    <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                      <div class="flex items-center justify-between gap-3">
+                        <div class="text-sm font-semibold text-[var(--cc-text)]">{{ decision.title }}</div>
+                        <div class="text-xs text-[var(--cc-text-soft)]">{{ decision.date }}</div>
+                      </div>
+                      @if (decision.status) {
+                        <div class="mt-2 text-xs font-medium uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">{{ decision.status }}</div>
+                      }
+                      <p class="mt-3 text-sm leading-6 text-[var(--cc-text-muted)]">{{ decision.preview }}</p>
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+          </section>
+        </article>
+      </section>
+    </app-view-shell>
+  `,
+})
+export class NotesPage {
+  private readonly data = inject(DashboardDataService);
+
+  protected readonly notes = this.data.notes();
+  protected readonly standup = this.data.standup();
+  protected readonly meta = computed(() => {
+    const noteBits = this.notes.data()?.dailyNote ? this.notes.data()!.dailyNote!.date : 'No recent daily note';
+    const decisions = this.notes.data()?.decisions.length ?? 0;
+    return `${noteBits} · ${decisions} decisions`;
+  });
+
+  protected refresh(): void {
+    this.notes.refresh();
+    this.standup.refresh();
+  }
+
+  protected cleanedBullet(bullet: string): string {
+    return bullet.replace(/\*\*/g, '').replace(/`/g, '');
+  }
+}

--- a/frontend/src/app/features/repos/repos.page.ts
+++ b/frontend/src/app/features/repos/repos.page.ts
@@ -1,0 +1,136 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { PinService } from '../../core/state/pin.service';
+import { RepoSummary } from '../../models/api';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-repos-page',
+  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="Pass 1" title="Repositories" subtitle="Repository health, open issue counts, and repo-to-issues handoff now run from Angular." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-pill tone="info">Angular secondary view</cc-pill>
+        <button type="button" (click)="repos.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search repos…" />
+      </div>
+
+      @if (repos.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading repositories" message="Reading tracked repository health and issue counts from the shared repo resource."></cc-state-panel>
+      } @else if (repos.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="Repos unavailable" [message]="repos.error() || 'Repository health could not be loaded.'"></cc-state-panel>
+      } @else if (!filteredItems().length) {
+        <cc-state-panel kind="empty" [title]="allItems().length ? 'No repos match this filter' : 'No repos configured'" [message]="allItems().length ? 'Try a different search.' : 'Add tracked repos in command-center config to populate this view.'"></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @if (pinnedItems().length) {
+            <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
+            @for (repo of pinnedItems(); track repo.repoFull) {
+              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <div class="text-base font-semibold text-[var(--cc-text)]">{{ repo.repo }}</div>
+                    <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                      @if (repo.archived) {
+                        <span>archived</span>
+                      }
+                      @if (repo.tracked) {
+                        <span class="text-emerald-300">tracked</span>
+                      }
+                    </div>
+                  </div>
+                  <button type="button" (click)="togglePinned(repo)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                </div>
+                <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
+                  <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
+                  <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
+                  <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
+                </div>
+                <div class="mt-4 flex flex-wrap gap-3">
+                  <button type="button" (click)="openIssueFilter(repo)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-muted)]">View in issues</button>
+                  <a [href]="'https://github.com/' + repo.repoFull + '/issues'" target="_blank" class="inline-flex rounded-full border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-amber-200">GitHub ↗</a>
+                </div>
+              </article>
+            }
+            @if (unpinnedItems().length) {
+              <div class="lg:col-span-2 2xl:col-span-3 border-t border-[var(--cc-border)]"></div>
+            }
+          }
+
+          @for (repo of unpinnedItems(); track repo.repoFull) {
+            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <div class="text-base font-semibold text-[var(--cc-text)]">{{ repo.repo }}</div>
+                  <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
+                    @if (repo.archived) {
+                      <span>archived</span>
+                    }
+                    @if (repo.tracked) {
+                      <span class="text-emerald-300">tracked</span>
+                    }
+                    @if (repo.lastActivity) {
+                      <span>Last issue {{ timeAgo(repo.lastActivity) }}</span>
+                    }
+                  </div>
+                </div>
+                <button type="button" (click)="togglePinned(repo)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+              </div>
+              <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
+                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
+                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
+                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
+              </div>
+              <div class="mt-4 flex flex-wrap gap-3">
+                <button type="button" (click)="openIssueFilter(repo)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-muted)]">View in issues</button>
+                <a [href]="'https://github.com/' + repo.repoFull + '/issues'" target="_blank" class="inline-flex rounded-full border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-amber-200">GitHub ↗</a>
+              </div>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class ReposPage {
+  private readonly data = inject(DashboardDataService);
+  protected readonly pins = inject(PinService);
+  private readonly router = inject(Router);
+
+  protected readonly repos = this.data.repos();
+  protected readonly searchText = signal('');
+  protected readonly allItems = computed(() => [...(this.repos.data() ?? [])].sort((a, b) => b.openIssues - a.openIssues));
+  protected readonly filteredItems = computed(() => {
+    const q = this.searchText().trim().toLowerCase();
+    if (!q) return this.allItems();
+    return this.allItems().filter((repo) => repo.repo.toLowerCase().includes(q) || repo.repoFull.toLowerCase().includes(q));
+  });
+  protected readonly pinnedItems = computed(() => this.filteredItems().filter((repo) => this.pins.isPinned('repo', repo.repoFull)));
+  protected readonly unpinnedItems = computed(() => this.filteredItems().filter((repo) => !this.pins.isPinned('repo', repo.repoFull)));
+  protected readonly meta = computed(() => {
+    const openIssues = this.allItems().reduce((sum, repo) => sum + repo.openIssues, 0);
+    const summary = `${this.allItems().length} repos · ${openIssues} open`;
+    return this.repos.source()?.status ? `${summary} · ${this.repos.source()!.status}` : summary;
+  });
+
+  protected togglePinned(repo: RepoSummary): void {
+    this.pins.toggle('repo', repo.repoFull);
+  }
+
+  protected openIssueFilter(repo: RepoSummary): void {
+    this.router.navigate(['/issues/active'], { queryParams: { repo: repo.repo } });
+  }
+
+  protected timeAgo(iso: string): string {
+    const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+    if (!Number.isFinite(seconds)) return 'unknown';
+    if (seconds < 60) return `${seconds}s ago`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    return `${Math.floor(seconds / 86400)}d ago`;
+  }
+}

--- a/frontend/src/app/layout/app-shell.component.ts
+++ b/frontend/src/app/layout/app-shell.component.ts
@@ -15,15 +15,15 @@ import { ThemeToggleComponent } from './theme-toggle.component';
           <div class="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
             <div>
               <p class="text-xs font-semibold uppercase tracking-[0.35em] text-[var(--cc-text-soft)]">command.center rewrite</p>
-              <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">Angular daily-use views are live</h1>
+              <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">Angular now covers the full dashboard</h1>
               <p class="mt-3 max-w-3xl text-sm leading-7 text-[var(--cc-text-muted)]">
-                The rewrite now includes real Angular versions of Home, Issues, PRs, Tasks, and Done, backed by the shared shell, data layer, and interaction state services.
+                The rewrite now includes Angular versions of the major command-center views, backed by the shared shell, data layer, and interaction state services.
               </p>
             </div>
 
             <div class="flex flex-wrap items-center gap-3">
-              <cc-pill tone="accent">Issue #71</cc-pill>
-              <cc-pill>Daily-use Angular views</cc-pill>
+              <cc-pill tone="accent">Issue #72</cc-pill>
+              <cc-pill>Full Angular dashboard</cc-pill>
               <app-theme-toggle></app-theme-toggle>
             </div>
           </div>

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -175,9 +175,27 @@ export interface StandupResponse extends ApiEnvelope {
   updatedAt: number | null;
 }
 
+export interface AnalyticsTotals {
+  pageviews: number;
+  visitors: number;
+  visits: number;
+  bounces: number;
+  totaltime: number;
+}
+
+export interface AnalyticsSite {
+  name: string;
+  domain: string;
+  pageviews: number;
+  visitors: number;
+  visits: number;
+  bounces: number;
+  totaltime: number;
+}
+
 export interface AnalyticsResponse extends ApiEnvelope {
-  totals: unknown;
-  sites: unknown[];
+  totals: AnalyticsTotals;
+  sites: AnalyticsSite[];
   range: string;
   updatedAt: string | null;
 }


### PR DESCRIPTION
## Summary
- migrate the remaining secondary Angular views for notes, calendar, repos, infra, and analytics
- wire the remaining tabs/routes into Angular so the dashboard now has coverage across the full major view set
- add repo-to-issues handoff support so repo cards can route into filtered Angular issue views

## Testing
- npm --prefix frontend run build
- curl -I http://127.0.0.1:4200
- curl -s http://127.0.0.1:4200/main.js | grep -o 'Angular now covers the full dashboard'

Closes #72.
