### PR TITLE
Add parser and API smoke tests to command-center

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const express = require('express');
+
+function createApp(options) {
+  const {
+    cache,
+    sourceMeta,
+    sourceResponseStatus,
+    beginSource,
+    succeedSource,
+    failSource,
+    fetchGitHub,
+    fetchCalendars,
+    fetchTasks,
+    fetchNotes,
+    fetchStandup,
+    fetchPRs,
+    fetchAnalytics,
+    closeIssue,
+    loadInfraProcesses,
+    frontend,
+  } = options;
+
+  const app = express();
+
+  if (frontend?.hasAngularDist) {
+    app.use(express.static(frontend.distDir));
+  }
+
+  app.get('/api/issues', (req, res) => {
+    const source = sourceMeta('github');
+    if (!cache.issues) {
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+    }
+    const urgent = cache.issues.filter(issue => issue.priority === 'urgent');
+    const active = cache.issues.filter(issue => issue.priority === 'active');
+    const deferred = cache.issues.filter(issue => issue.priority === 'deferred');
+    return res.json({ ok: true, urgent, active, deferred, total: cache.issues.length, updatedAt: cache.issuesUpdatedAt, source });
+  });
+
+  app.get('/api/repos', (req, res) => {
+    const source = sourceMeta('github');
+    if (!cache.repoStats) {
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+    }
+    return res.json({ ok: true, repos: cache.repoStats, updatedAt: cache.issuesUpdatedAt, source });
+  });
+
+  app.get('/api/calendar', (req, res) => {
+    const source = sourceMeta('calendar');
+    if (!cache.events) {
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+    }
+    return res.json({ ok: true, events: cache.events, updatedAt: cache.eventsUpdatedAt, source });
+  });
+
+  app.get('/api/infra', (req, res) => {
+    beginSource('infra');
+    try {
+      const updatedAt = Date.now();
+      const processes = loadInfraProcesses();
+      succeedSource('infra', updatedAt);
+      return res.json({ ok: true, processes, updatedAt, source: sourceMeta('infra') });
+    } catch (error) {
+      failSource('infra', error);
+      const source = sourceMeta('infra');
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: error.message, processes: [], updatedAt: source.updatedAt, source });
+    }
+  });
+
+  app.get('/api/tasks', (req, res) => {
+    const source = sourceMeta('tasks');
+    if (!cache.tasks) {
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+    }
+    return res.json({ ok: true, tasks: cache.tasks, completedTasks: cache.completedTasks || [], updatedAt: cache.tasksUpdatedAt, source });
+  });
+
+  app.get('/api/prs', (req, res) => {
+    const source = sourceMeta('prs');
+    if (!cache.prs) {
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+    }
+    return res.json({ ok: true, prs: cache.prs, updatedAt: cache.prsUpdatedAt, source });
+  });
+
+  app.get('/api/standup', (req, res) => {
+    const source = sourceMeta('standup');
+    return res.json({ ok: true, standup: cache.standup || null, updatedAt: cache.standupUpdatedAt, source });
+  });
+
+  app.get('/api/analytics', (req, res) => {
+    const source = sourceMeta('analytics');
+    if (!cache.analytics) {
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+    }
+    return res.json({ ok: true, ...cache.analytics, source });
+  });
+
+  app.get('/api/notes', (req, res) => {
+    const source = sourceMeta('notes');
+    if (!cache.notes) {
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
+    }
+    return res.json({ ok: true, ...cache.notes, source });
+  });
+
+  app.post('/api/issues/:owner/:repo/:number/close', async (req, res) => {
+    try {
+      const { owner, repo, number } = req.params;
+      await closeIssue({ owner, repo, number });
+      fetchGitHub();
+      return res.json({ ok: true });
+    } catch (error) {
+      return res.status(500).json({ ok: false, error: error.message });
+    }
+  });
+
+  app.post('/api/refresh', async (req, res) => {
+    fetchGitHub();
+    await fetchCalendars();
+    fetchTasks();
+    fetchNotes();
+    fetchStandup();
+    fetchPRs();
+    fetchAnalytics();
+    return res.json({ ok: true });
+  });
+
+  app.get(/^(?!\/api(?:\/|$)).*/, (req, res) => {
+    if (!frontend?.hasAngularDist) {
+      return res.status(503).send('Angular build output not found. Run "npm run build:web" or start the dev server with "npm run dev".');
+    }
+
+    return res.sendFile(frontend.indexFile);
+  });
+
+  return app;
+}
+
+module.exports = { createApp };

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -1,0 +1,164 @@
+'use strict';
+
+function parseTaskRecord(raw, label, color, section, completed = false) {
+  const dueMatch = raw.match(/📅\s*(\d{4}-\d{2}-\d{2})/);
+  const completedAtMatch = raw.match(/✅\s*(\d{4}-\d{2}-\d{2})/);
+  const title = raw
+    .replace(/📅\s*\d{4}-\d{2}-\d{2}/g, '')
+    .replace(/✅\s*\d{4}-\d{2}-\d{2}/g, '')
+    .replace(/#\w+/g, '')
+    .replace(/🔁[^\n]*/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+  if (!title) return null;
+  return {
+    title,
+    source: label,
+    color,
+    section,
+    due: dueMatch ? dueMatch[1] : null,
+    recurring: raw.includes('🔁'),
+    completed,
+    completedAt: completedAtMatch ? completedAtMatch[1] : null,
+  };
+}
+
+function parseStandupSections(content) {
+  const yesterdayMatch = content.match(/## Yesterday\s*\n([\s\S]*?)(?=\n## [^\n]+|$)/);
+  const yesterday = (yesterdayMatch ? yesterdayMatch[1] : content).trim();
+  const lines = yesterday.split('\n');
+  const sections = [];
+
+  let current = null;
+  let currentCategory = null;
+
+  const finalizeCurrent = () => {
+    if (!current) return;
+
+    if (current.noActivity) {
+      sections.push({
+        repo: current.repo,
+        stats: '',
+        bullets: [current.noActivity],
+      });
+      current = null;
+      currentCategory = null;
+      return;
+    }
+
+    const nonEmptyCategories = current.categories.filter(cat => cat.items.length || cat.label);
+    const stats = nonEmptyCategories
+      .filter(cat => cat.items.length)
+      .map(cat => `${cat.items.length} ${cat.label}`)
+      .join(' · ');
+
+    const bullets = [];
+    for (const cat of nonEmptyCategories) {
+      if (!cat.items.length) {
+        bullets.push(cat.label);
+        continue;
+      }
+      for (const item of cat.items) {
+        bullets.push(`${cat.label}: ${item}`);
+        if (bullets.length >= 4) break;
+      }
+      if (bullets.length >= 4) break;
+    }
+
+    sections.push({
+      repo: current.repo,
+      stats,
+      bullets: bullets.length ? bullets : ['No parsed items'],
+    });
+
+    current = null;
+    currentCategory = null;
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    if (line.startsWith('### ')) {
+      finalizeCurrent();
+      current = { repo: line.slice(4).trim(), noActivity: null, categories: [] };
+      currentCategory = null;
+      continue;
+    }
+
+    if (!current) continue;
+
+    if (/^- No (GitHub )?activity/i.test(trimmed)) {
+      current.noActivity = trimmed.replace(/^-\s*/, '').replace(/\.$/, '');
+      currentCategory = null;
+      continue;
+    }
+
+    if (/^\s+- /.test(line) && !/^- /.test(line) && currentCategory) {
+      currentCategory.items.push(
+        trimmed.replace(/^-\s*/, '').replace(/\*Closes[^*]*\*/g, '').replace(/`/g, '').trim()
+      );
+      continue;
+    }
+
+    if (/^- /.test(line)) {
+      const label = trimmed.replace(/^-\s*/, '').replace(/:$/, '').trim();
+      currentCategory = { label, items: [] };
+      current.categories.push(currentCategory);
+      continue;
+    }
+  }
+
+  finalizeCurrent();
+  return sections;
+}
+
+function extractDailyNotePreview(noteContent, noteDate, now = new Date()) {
+  const pad = n => String(n).padStart(2, '0');
+  const year = now.getFullYear();
+  const month = pad(now.getMonth() + 1);
+  const day = pad(now.getDate());
+
+  const body = noteContent.replace(/^---[\s\S]*?---\n/, '');
+  const clean = body
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/>[^\n]*/g, '')
+    .replace(/!\[\[[^\]]*\]\]/g, '')
+    .replace(/\[\[[^\]|]*(?:\|([^\]]+))?\]\]/g, (_, alt) => alt || '')
+    .replace(/#{1,6}\s/g, '')
+    .trim();
+  const lines = clean.split('\n').map(l => l.trim()).filter(l => l.length > 20);
+
+  return {
+    date: noteDate,
+    preview: lines.slice(0, 3).join(' ').substring(0, 300),
+    isToday: noteDate === `${year}-${month}-${day}`,
+  };
+}
+
+function extractDecisionSummary(content, fileName) {
+  const titleMatch = content.match(/^#\s+(.+)/m);
+  const statusMatch = content.match(/\*\*Status:\*\*\s*(.+)/i);
+  const dateMatch = content.match(/\*\*Date:\*\*\s*(\S+)/i);
+  const contextLines = content.split('\n')
+    .filter(line => line.trim().length > 20 && !line.startsWith('#') && !line.startsWith('**'))
+    .slice(0, 2)
+    .join(' ')
+    .substring(0, 200);
+
+  return {
+    title: titleMatch ? titleMatch[1].replace('Decision: ', '') : fileName.replace('.md', ''),
+    status: statusMatch ? statusMatch[1].trim() : null,
+    date: dateMatch ? dateMatch[1].trim() : fileName.substring(0, 10),
+    preview: contextLines,
+    file: fileName.replace('.md', ''),
+  };
+}
+
+module.exports = {
+  parseTaskRecord,
+  parseStandupSections,
+  extractDailyNotePreview,
+  extractDecisionSummary,
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "concurrently -k -n api,web -c yellow,cyan \"npm run dev:api\" \"npm run dev:web\"",
     "build:web": "npm --prefix frontend run build",
     "check": "npm run build:web && node --check server.js",
-    "test": "npm run check"
+    "test:server": "node --test test/*.test.js",
+    "test": "npm run test:server && npm run check"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -2,15 +2,19 @@
 
 require('dotenv').config();
 
-const express = require('express');
 const { execSync } = require('child_process');
 const path = require('path');
 const cron = require('node-cron');
 const ical = require('node-ical');
 const fs = require('fs');
+const { createApp } = require('./lib/create-app');
 const { loadConfig } = require('./lib/config');
-
-const app = express();
+const {
+  parseTaskRecord,
+  parseStandupSections,
+  extractDailyNotePreview,
+  extractDecisionSummary,
+} = require('./lib/parsers');
 const { config: runtimeConfig, configPath, warnings: configWarnings } = loadConfig();
 const PORT = runtimeConfig.server.port;
 const HOST = runtimeConfig.server.host;
@@ -174,28 +178,6 @@ function sourceResponseStatus(source) {
   return source.status === 'failed' ? 500 : 503;
 }
 
-function parseTaskRecord(raw, label, color, section, completed = false) {
-  const dueMatch = raw.match(/📅\s*(\d{4}-\d{2}-\d{2})/);
-  const completedAtMatch = raw.match(/✅\s*(\d{4}-\d{2}-\d{2})/);
-  const title = raw
-    .replace(/📅\s*\d{4}-\d{2}-\d{2}/g, '')
-    .replace(/✅\s*\d{4}-\d{2}-\d{2}/g, '')
-    .replace(/#\w+/g, '')
-    .replace(/🔁[^\n]*/g, '')
-    .trim();
-  if (!title) return null;
-  return {
-    title,
-    source: label,
-    color,
-    section,
-    due: dueMatch ? dueMatch[1] : null,
-    recurring: raw.includes('🔁'),
-    completed,
-    completedAt: completedAtMatch ? completedAtMatch[1] : null,
-  };
-}
-
 // ── Pull Requests ───────────────────────────────────────────────────────────────
 function fetchPRs() {
   console.log('[prs] fetching open PRs...');
@@ -235,97 +217,6 @@ function fetchPRs() {
 }
 
 // ── Standup ───────────────────────────────────────────────────────────────────
-function parseStandupSections(content) {
-  const yesterdayMatch = content.match(/## Yesterday\s*\n([\s\S]*?)(?=\n## [^\n]+|$)/);
-  const yesterday = (yesterdayMatch ? yesterdayMatch[1] : content).trim();
-  const lines = yesterday.split('\n');
-  const sections = [];
-
-  let current = null;
-  let currentCategory = null;
-
-  const finalizeCurrent = () => {
-    if (!current) return;
-
-    if (current.noActivity) {
-      sections.push({
-        repo: current.repo,
-        stats: '',
-        bullets: [current.noActivity],
-      });
-      current = null;
-      currentCategory = null;
-      return;
-    }
-
-    const nonEmptyCategories = current.categories.filter(cat => cat.items.length || cat.label);
-    const stats = nonEmptyCategories
-      .filter(cat => cat.items.length)
-      .map(cat => `${cat.items.length} ${cat.label}`)
-      .join(' · ');
-
-    const bullets = [];
-    for (const cat of nonEmptyCategories) {
-      if (!cat.items.length) {
-        bullets.push(cat.label);
-        continue;
-      }
-      for (const item of cat.items) {
-        bullets.push(`${cat.label}: ${item}`);
-        if (bullets.length >= 4) break;
-      }
-      if (bullets.length >= 4) break;
-    }
-
-    sections.push({
-      repo: current.repo,
-      stats,
-      bullets: bullets.length ? bullets : ['No parsed items'],
-    });
-
-    current = null;
-    currentCategory = null;
-  };
-
-  for (const rawLine of lines) {
-    const line = rawLine.replace(/\r$/, '');
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-
-    if (line.startsWith('### ')) {
-      finalizeCurrent();
-      current = { repo: line.slice(4).trim(), noActivity: null, categories: [] };
-      currentCategory = null;
-      continue;
-    }
-
-    if (!current) continue;
-
-    if (/^- No (GitHub )?activity/i.test(trimmed)) {
-      current.noActivity = trimmed.replace(/^-\s*/, '').replace(/\.$/, '');
-      currentCategory = null;
-      continue;
-    }
-
-    if (/^\s+- /.test(line) && !/^- /.test(line) && currentCategory) {
-      currentCategory.items.push(
-        trimmed.replace(/^-\s*/, '').replace(/\*Closes[^*]*\*/g, '').replace(/`/g, '').trim()
-      );
-      continue;
-    }
-
-    if (/^- /.test(line)) {
-      const label = trimmed.replace(/^-\s*/, '').replace(/:$/, '').trim();
-      currentCategory = { label, items: [] };
-      current.categories.push(currentCategory);
-      continue;
-    }
-  }
-
-  finalizeCurrent();
-  return sections;
-}
-
 function fetchStandup() {
   console.log('[standup] reading latest standup...');
   beginSource('standup');
@@ -389,8 +280,6 @@ function fetchNotes() {
     // Find today's or most recent daily note
     const months = ['01-January','02-February','03-March','04-April','05-May','06-June',
       '07-July','08-August','09-September','10-October','11-November','12-December'];
-    const year = now.getFullYear();
-    const month = months[now.getMonth()];
     const pad = n => String(n).padStart(2,'0');
     // Try today, then walk back up to 7 days
     let noteContent = null, noteDate = null;
@@ -409,23 +298,7 @@ function fetchNotes() {
     }
 
     if (noteContent) {
-      // Strip frontmatter
-      const body = noteContent.replace(/^---[\s\S]*?---\n/, '');
-      // Strip Obsidian code blocks and button syntax
-      const clean = body
-        .replace(/```[\s\S]*?```/g, '')
-        .replace(/>[^\n]*/g, '') // blockquotes
-        .replace(/!\[\[[^\]]*\]\]/g, '') // embeds
-        .replace(/\[\[[^\]|]*(?:\|([^\]]+))?\]\]/g, (_, alt) => alt || '')
-        .replace(/#{1,6}\s/g, '')
-        .trim();
-      // First meaningful paragraph
-      const lines = clean.split('\n').map(l => l.trim()).filter(l => l.length > 20);
-      result.dailyNote = {
-        date: noteDate,
-        preview: lines.slice(0, 3).join(' ').substring(0, 300),
-        isToday: noteDate === `${year}-${pad(now.getMonth()+1)}-${pad(now.getDate())}`,
-      };
+      result.dailyNote = extractDailyNotePreview(noteContent, noteDate, now);
     }
 
     // Recent decisions
@@ -435,19 +308,7 @@ function fetchNotes() {
         .sort().reverse().slice(0, 5);
       for (const file of files) {
         const content = fs.readFileSync(`${DECISIONS_DIR}/${file}`, 'utf8');
-        const titleMatch = content.match(/^#\s+(.+)/m);
-        const statusMatch = content.match(/\*\*Status:\*\*\s*(.+)/i);
-        const dateMatch = content.match(/\*\*Date:\*\*\s*(\S+)/i);
-        const contextLines = content.split('\n')
-          .filter(l => l.trim().length > 20 && !l.startsWith('#') && !l.startsWith('**'))
-          .slice(0, 2).join(' ').substring(0, 200);
-        result.decisions.push({
-          title: titleMatch ? titleMatch[1].replace('Decision: ','') : file.replace('.md',''),
-          status: statusMatch ? statusMatch[1].trim() : null,
-          date: dateMatch ? dateMatch[1].trim() : file.substring(0,10),
-          preview: contextLines,
-          file: file.replace('.md',''),
-        });
+        result.decisions.push(extractDecisionSummary(content, file));
       }
     }
 
@@ -733,149 +594,71 @@ async function fetchAnalytics() {
   }
 }
 
-// ── Schedules ─────────────────────────────────────────────────────────────────
-cron.schedule('*/5 * * * *', fetchGitHub);
-cron.schedule('*/10 * * * *', fetchCalendars);
-cron.schedule('*/2 * * * *', fetchTasks);
-cron.schedule('*/5 * * * *', fetchNotes);
-cron.schedule('*/10 * * * *', fetchStandup);
-cron.schedule('*/5 * * * *', fetchPRs);
-cron.schedule('*/15 * * * *', fetchAnalytics);
-
-fetchGitHub();
-fetchCalendars();
-fetchTasks();
-fetchNotes();
-fetchStandup();
-fetchPRs();
-fetchAnalytics();
-
-// ── Routes ────────────────────────────────────────────────────────────────────
-if (HAS_ANGULAR_DIST) {
-  app.use(express.static(ANGULAR_DIST_DIR));
+function loadInfraProcesses() {
+  const raw = execSync('pm2 jlist', { encoding: 'utf8' });
+  const processes = JSON.parse(raw);
+  return processes.map(process => ({
+    id: process.pm_id,
+    name: process.name,
+    status: process.pm2_env.status,
+    pid: process.pid,
+    uptime: process.pm2_env.status === 'online' ? Date.now() - process.pm2_env.pm_uptime : null,
+    restarts: process.pm2_env.restart_time,
+    cpu: process.monit?.cpu ?? 0,
+    memory: process.monit?.memory ?? 0,
+  }));
 }
 
-app.get('/api/issues', (req, res) => {
-  const source = sourceMeta('github');
-  if (!cache.issues) {
-    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
-  }
-  const urgent = cache.issues.filter(i => i.priority === 'urgent');
-  const active = cache.issues.filter(i => i.priority === 'active');
-  const deferred = cache.issues.filter(i => i.priority === 'deferred');
-  res.json({ ok: true, urgent, active, deferred, total: cache.issues.length, updatedAt: cache.issuesUpdatedAt, source });
+const app = createApp({
+  cache,
+  sourceMeta,
+  sourceResponseStatus,
+  beginSource,
+  succeedSource,
+  failSource,
+  fetchGitHub,
+  fetchCalendars,
+  fetchTasks,
+  fetchNotes,
+  fetchStandup,
+  fetchPRs,
+  fetchAnalytics,
+  closeIssue: ({ owner, repo, number }) => execSync(`gh issue close ${number} --repo ${owner}/${repo}`, { encoding: 'utf8' }),
+  loadInfraProcesses,
+  frontend: {
+    hasAngularDist: HAS_ANGULAR_DIST,
+    distDir: ANGULAR_DIST_DIR,
+    indexFile: ANGULAR_INDEX_FILE,
+  },
 });
 
-app.get('/api/repos', (req, res) => {
-  const source = sourceMeta('github');
-  if (!cache.repoStats) {
-    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
-  }
-  res.json({ ok: true, repos: cache.repoStats, updatedAt: cache.issuesUpdatedAt, source });
-});
+// ── Schedules ─────────────────────────────────────────────────────────────────
+if (require.main === module) {
+  cron.schedule('*/5 * * * *', fetchGitHub);
+  cron.schedule('*/10 * * * *', fetchCalendars);
+  cron.schedule('*/2 * * * *', fetchTasks);
+  cron.schedule('*/5 * * * *', fetchNotes);
+  cron.schedule('*/10 * * * *', fetchStandup);
+  cron.schedule('*/5 * * * *', fetchPRs);
+  cron.schedule('*/15 * * * *', fetchAnalytics);
 
-app.get('/api/calendar', (req, res) => {
-  const source = sourceMeta('calendar');
-  if (!cache.events) {
-    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
-  }
-  res.json({ ok: true, events: cache.events, updatedAt: cache.eventsUpdatedAt, source });
-});
-
-// Infra — PM2 process list
-app.get('/api/infra', (req, res) => {
-  beginSource('infra');
-  try {
-    const raw = execSync('pm2 jlist', { encoding: 'utf8' });
-    const processes = JSON.parse(raw);
-    const updatedAt = Date.now();
-    const data = processes.map(p => ({
-      id: p.pm_id,
-      name: p.name,
-      status: p.pm2_env.status,
-      pid: p.pid,
-      uptime: p.pm2_env.status === 'online' ? Date.now() - p.pm2_env.pm_uptime : null,
-      restarts: p.pm2_env.restart_time,
-      cpu: p.monit?.cpu ?? 0,
-      memory: p.monit?.memory ?? 0,
-    }));
-    succeedSource('infra', updatedAt);
-    res.json({ ok: true, processes: data, updatedAt, source: sourceMeta('infra') });
-  } catch (err) {
-    failSource('infra', err);
-    const source = sourceMeta('infra');
-    res.status(sourceResponseStatus(source)).json({ ok: false, error: err.message, processes: [], updatedAt: source.updatedAt, source });
-  }
-});
-
-app.get('/api/tasks', (req, res) => {
-  const source = sourceMeta('tasks');
-  if (!cache.tasks) {
-    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
-  }
-  res.json({ ok: true, tasks: cache.tasks, completedTasks: cache.completedTasks || [], updatedAt: cache.tasksUpdatedAt, source });
-});
-
-app.get('/api/prs', (req, res) => {
-  const source = sourceMeta('prs');
-  if (!cache.prs) {
-    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
-  }
-  res.json({ ok: true, prs: cache.prs, updatedAt: cache.prsUpdatedAt, source });
-});
-
-app.get('/api/standup', (req, res) => {
-  const source = sourceMeta('standup');
-  res.json({ ok: true, standup: cache.standup || null, updatedAt: cache.standupUpdatedAt, source });
-});
-
-app.get('/api/analytics', (req, res) => {
-  const source = sourceMeta('analytics');
-  if (!cache.analytics) {
-    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
-  }
-  res.json({ ok: true, ...cache.analytics, source });
-});
-
-app.get('/api/notes', (req, res) => {
-  const source = sourceMeta('notes');
-  if (!cache.notes) {
-    return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
-  }
-  res.json({ ok: true, ...cache.notes, source });
-});
-
-// Quick issue close
-app.post('/api/issues/:owner/:repo/:number/close', (req, res) => {
-  try {
-    const { owner, repo, number } = req.params;
-    execSync(`gh issue close ${number} --repo ${owner}/${repo}`, { encoding: 'utf8' });
-    // Trigger background refresh
-    fetchGitHub();
-    res.json({ ok: true });
-  } catch (err) {
-    res.status(500).json({ ok: false, error: err.message });
-  }
-});
-
-app.post('/api/refresh', async (req, res) => {
   fetchGitHub();
-  await fetchCalendars();
+  fetchCalendars();
   fetchTasks();
   fetchNotes();
   fetchStandup();
   fetchPRs();
-  res.json({ ok: true });
-});
+  fetchAnalytics();
 
-app.get(/^(?!\/api(?:\/|$)).*/, (req, res) => {
-  if (!HAS_ANGULAR_DIST) {
-    return res.status(503).send('Angular build output not found. Run "npm run build:web" or start the dev server with "npm run dev".');
-  }
+  app.listen(PORT, HOST, () => {
+    console.log(`command-center running at http://${HOST}:${PORT}`);
+  });
+}
 
-  return res.sendFile(ANGULAR_INDEX_FILE);
-});
-
-app.listen(PORT, HOST, () => {
-  console.log(`command-center running at http://${HOST}:${PORT}`);
-});
+module.exports = {
+  app,
+  cache,
+  sourceMeta,
+  sourceResponseStatus,
+  loadInfraProcesses,
+};

--- a/test/api-smoke.test.js
+++ b/test/api-smoke.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createApp } = require('../lib/create-app');
+
+function sourceMetaFactory(overrides = {}) {
+  return key => ({
+    key,
+    label: key,
+    status: 'fresh',
+    loading: false,
+    stale: false,
+    updatedAt: 1713124800000,
+    ageMs: 1000,
+    lastAttemptAt: 1713124800000,
+    error: null,
+    errorAt: null,
+    staleAfterMs: 60000,
+    ...(overrides[key] || {}),
+  });
+}
+
+function createTestApp({ cacheOverrides = {}, sourceOverrides = {}, infraError = null } = {}) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'command-center-test-'));
+  const indexFile = path.join(tempDir, 'index.html');
+  fs.writeFileSync(indexFile, '<!doctype html><html><body><app-root></app-root></body></html>');
+
+  const cache = {
+    issues: [
+      { title: 'Fix home render', priority: 'urgent' },
+      { title: 'Polish issues view', priority: 'active' },
+      { title: 'Someday feature', priority: 'deferred' },
+    ],
+    repoStats: [{ repo: 'command-center', repoFull: 'DamageLabs/command-center', openIssues: 3, bugs: 1, enhancements: 2 }],
+    events: [{ summary: 'Standup', start: '2026-04-15T14:00:00Z' }],
+    tasks: [{ title: 'Ship tests' }],
+    completedTasks: [{ title: 'Merge #73', completedAt: '2026-04-14' }],
+    notes: { dailyNote: { date: '2026-04-14', preview: 'Daily note preview', isToday: true }, decisions: [] },
+    standup: { date: '2026-04-14', sections: [{ repo: 'DamageLabs/command-center', stats: '1 PRs', bullets: ['PRs: Ship Angular'] }] },
+    prs: [{ title: 'Add smoke tests', repo: 'command-center' }],
+    analytics: { totals: { pageviews: 42, visitors: 21, visits: 25, bounces: 5, totaltime: 180 }, sites: [] },
+    prsUpdatedAt: 1713124800000,
+    issuesUpdatedAt: 1713124800000,
+    eventsUpdatedAt: 1713124800000,
+    tasksUpdatedAt: 1713124800000,
+    notesUpdatedAt: 1713124800000,
+    standupUpdatedAt: 1713124800000,
+    analyticsUpdatedAt: 1713124800000,
+    ...cacheOverrides,
+  };
+
+  const refreshCalls = [];
+  const app = createApp({
+    cache,
+    sourceMeta: sourceMetaFactory(sourceOverrides),
+    sourceResponseStatus: source => (source.status === 'failed' ? 500 : 503),
+    beginSource: () => {},
+    succeedSource: () => {},
+    failSource: () => {},
+    fetchGitHub: () => refreshCalls.push('github'),
+    fetchCalendars: async () => refreshCalls.push('calendar'),
+    fetchTasks: () => refreshCalls.push('tasks'),
+    fetchNotes: () => refreshCalls.push('notes'),
+    fetchStandup: () => refreshCalls.push('standup'),
+    fetchPRs: () => refreshCalls.push('prs'),
+    fetchAnalytics: () => refreshCalls.push('analytics'),
+    closeIssue: async () => refreshCalls.push('closeIssue'),
+    loadInfraProcesses: () => {
+      if (infraError) throw infraError;
+      return [{ id: 1, name: 'command-center', status: 'online', pid: 1234, uptime: 5000, restarts: 0, cpu: 1, memory: 2048 }];
+    },
+    frontend: {
+      hasAngularDist: true,
+      distDir: tempDir,
+      indexFile,
+    },
+  });
+
+  return { app, refreshCalls, cleanup: () => fs.rmSync(tempDir, { recursive: true, force: true }) };
+}
+
+async function withServer(app, fn) {
+  const server = await new Promise(resolve => {
+    const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+  });
+
+  try {
+    const address = server.address();
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    return await fn(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => server.close(error => (error ? reject(error) : resolve())));
+  }
+}
+
+test('main API routes return smoke-level shapes', async () => {
+  const { app, cleanup } = createTestApp();
+
+  try {
+    await withServer(app, async baseUrl => {
+      const issues = await fetch(`${baseUrl}/api/issues`).then(res => res.json());
+      assert.equal(issues.ok, true);
+      assert.equal(issues.urgent.length, 1);
+      assert.equal(issues.active.length, 1);
+      assert.equal(issues.deferred.length, 1);
+
+      const repos = await fetch(`${baseUrl}/api/repos`).then(res => res.json());
+      assert.equal(repos.ok, true);
+      assert.equal(repos.repos.length, 1);
+
+      const tasks = await fetch(`${baseUrl}/api/tasks`).then(res => res.json());
+      assert.equal(tasks.ok, true);
+      assert.equal(tasks.completedTasks.length, 1);
+
+      const notes = await fetch(`${baseUrl}/api/notes`).then(res => res.json());
+      assert.equal(notes.ok, true);
+      assert.equal(notes.dailyNote.date, '2026-04-14');
+
+      const standup = await fetch(`${baseUrl}/api/standup`).then(res => res.json());
+      assert.equal(standup.ok, true);
+      assert.equal(standup.standup.sections.length, 1);
+
+      const analytics = await fetch(`${baseUrl}/api/analytics`).then(res => res.json());
+      assert.equal(analytics.ok, true);
+      assert.equal(analytics.totals.pageviews, 42);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('infra route returns degraded-state response when process collection fails', async () => {
+  const { app, cleanup } = createTestApp({
+    infraError: new Error('pm2 jlist failed'),
+    sourceOverrides: { infra: { status: 'failed', error: 'pm2 jlist failed' } },
+  });
+
+  try {
+    await withServer(app, async baseUrl => {
+      const response = await fetch(`${baseUrl}/api/infra`);
+      const body = await response.json();
+
+      assert.equal(response.status, 500);
+      assert.equal(body.ok, false);
+      assert.deepEqual(body.processes, []);
+      assert.match(body.error, /pm2 jlist failed/);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('refresh route triggers all configured refreshers', async () => {
+  const { app, refreshCalls, cleanup } = createTestApp();
+
+  try {
+    await withServer(app, async baseUrl => {
+      const response = await fetch(`${baseUrl}/api/refresh`, { method: 'POST' });
+      const body = await response.json();
+      assert.equal(response.status, 200);
+      assert.equal(body.ok, true);
+    });
+
+    assert.deepEqual(refreshCalls, ['github', 'calendar', 'tasks', 'notes', 'standup', 'prs', 'analytics']);
+  } finally {
+    cleanup();
+  }
+});
+
+test('non-API routes fall back to the Angular index file', async () => {
+  const { app, cleanup } = createTestApp();
+
+  try {
+    await withServer(app, async baseUrl => {
+      const response = await fetch(`${baseUrl}/issues/active`);
+      const html = await response.text();
+
+      assert.equal(response.status, 200);
+      assert.match(html, /<app-root><\/app-root>/);
+    });
+  } finally {
+    cleanup();
+  }
+});

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseTaskRecord,
+  parseStandupSections,
+  extractDailyNotePreview,
+  extractDecisionSummary,
+} = require('../lib/parsers');
+
+test('parseTaskRecord strips metadata and keeps due date/recurring state', () => {
+  const task = parseTaskRecord('Ship #todo dashboard polish 📅 2026-04-20 🔁 every week', 'Work', 'blue', 'Sprint', false);
+
+  assert.deepEqual(task, {
+    title: 'Ship dashboard polish',
+    source: 'Work',
+    color: 'blue',
+    section: 'Sprint',
+    due: '2026-04-20',
+    recurring: true,
+    completed: false,
+    completedAt: null,
+  });
+});
+
+test('parseTaskRecord captures completion date for completed tasks', () => {
+  const task = parseTaskRecord('Merge PR ✅ 2026-04-14', 'Work', 'blue', 'Done', true);
+
+  assert.equal(task.completed, true);
+  assert.equal(task.completedAt, '2026-04-14');
+  assert.equal(task.title, 'Merge PR');
+});
+
+test('parseStandupSections handles nested bullets and trims close markers', () => {
+  const content = `# Daily Standup\n\n## Yesterday\n### DamageLabs/command-center\n- PRs\n  - Finish Angular cutover *Closes #73*\n- Issues\n  - Add API smoke coverage\n### DamageLabs/openclaw-ops\n- No activity.\n\n## Today\n- keep going\n`;
+
+  const sections = parseStandupSections(content);
+
+  assert.equal(sections.length, 2);
+  assert.deepEqual(sections[0], {
+    repo: 'DamageLabs/command-center',
+    stats: '1 PRs · 1 Issues',
+    bullets: ['PRs: Finish Angular cutover', 'Issues: Add API smoke coverage'],
+  });
+  assert.deepEqual(sections[1], {
+    repo: 'DamageLabs/openclaw-ops',
+    stats: '',
+    bullets: ['No activity'],
+  });
+});
+
+test('extractDailyNotePreview strips frontmatter, embeds, code blocks, and wiki links', () => {
+  const note = `---\ntags: [daily]\n---\n# Heading\n![[image.png]]\n\nThis is the first real paragraph with enough text to keep.\n\n> ignore quote\n\n[[DamageLabs/command-center|Command Center]] got the Angular cutover done.\n\n\`\`\`js\nconsole.log('ignore me')\n\`\`\`\n\nAnother paragraph with enough text to keep as well.`;
+
+  const preview = extractDailyNotePreview(note, '2026-04-14', new Date('2026-04-14T12:00:00Z'));
+
+  assert.equal(preview.date, '2026-04-14');
+  assert.equal(preview.isToday, true);
+  assert.match(preview.preview, /This is the first real paragraph/);
+  assert.match(preview.preview, /Command Center got the Angular cutover done/);
+  assert.doesNotMatch(preview.preview, /console\.log/);
+  assert.doesNotMatch(preview.preview, /image\.png/);
+});
+
+test('extractDecisionSummary prefers explicit metadata when present', () => {
+  const content = `# Decision: Ship Angular as default UI\n\n**Status:** Accepted\n**Date:** 2026-04-14\n\nThis decision locks in Angular as the shipped frontend.\n\nSecond supporting sentence with more context.`;
+
+  const summary = extractDecisionSummary(content, '2026-04-14-ship-angular.md');
+
+  assert.deepEqual(summary, {
+    title: 'Ship Angular as default UI',
+    status: 'Accepted',
+    date: '2026-04-14',
+    preview: 'This decision locks in Angular as the shipped frontend. Second supporting sentence with more context.',
+    file: '2026-04-14-ship-angular',
+  });
+});


### PR DESCRIPTION
## Summary
- extract parser helpers and route creation so the backend can be tested without booting the live runtime
- add real parser coverage for standup, tasks, daily note extraction, and decision summaries
- add API smoke tests for the main dashboard endpoints and replace the placeholder npm test path with a real test run

## Testing
- npm test

Closes #49.
