### PR TITLE
Remove rollout copy from the Angular UI

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -17,10 +17,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render the full Angular dashboard heading', async () => {
+  it('should render the Command Center heading', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Angular now covers the full dashboard');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Command Center');
   });
 });

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -25,14 +25,12 @@ interface PinnedHomeItem {
   imports: [ViewShellComponent, CardComponent, PillComponent, StatePanelComponent],
   template: `
     <app-view-shell
-      eyebrow="Layer 2"
-      title="Home dashboard"
-      subtitle="Angular Home now carries the daily command-center view, including reminders, pinned items, upcoming events, issue/task summaries, the latest daily note, and standup context."
+      eyebrow="Overview"
+      title="Home"
+      subtitle="Your daily command-center view, including reminders, pinned items, upcoming events, issue and task summaries, the latest daily note, and standup context."
       [meta]="homeMeta()"
     >
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="accent">Angular Home</cc-pill>
-        <cc-pill tone="info">Two-layer migration</cc-pill>
         <button type="button" (click)="refreshAll()" [disabled]="refreshingAll()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)] disabled:cursor-not-allowed disabled:opacity-60">
           {{ refreshingAll() ? 'Refreshing…' : 'Refresh sources' }}
         </button>

--- a/frontend/src/app/features/shared/placeholder-page.component.ts
+++ b/frontend/src/app/features/shared/placeholder-page.component.ts
@@ -11,38 +11,38 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   imports: [RouterLink, ViewShellComponent, CardComponent, PillComponent, StatePanelComponent],
   template: `
     <app-view-shell
-      eyebrow="Migration target"
+      eyebrow="Coming soon"
       [title]="title"
       [subtitle]="description"
-      meta="This route exists now so future feature work lands inside the shared shell instead of inventing its own structure."
+      meta="This route is reserved and ready when the feature is implemented."
     >
       <div view-actions>
-        <cc-pill tone="info">Route shell ready</cc-pill>
+        <cc-pill tone="info">Placeholder</cc-pill>
       </div>
 
       <section class="grid gap-6 xl:grid-cols-[1.25fr_0.9fr]">
         <cc-card
-          eyebrow="Why this matters"
-          title="The route exists before the feature"
-          description="That sounds small, but it keeps the migration honest. The Angular rewrite can now land feature work into a stable shell instead of mixing routing, page chrome, and business logic in one pass."
+          eyebrow="Status"
+          title="This view is not wired up yet"
+          description="The page shell is in place so the eventual feature can land cleanly without inventing a new layout."
         >
           <div class="space-y-3 text-sm leading-6 text-[var(--cc-text-muted)]">
-            <p>• route-level framing is shared and reusable</p>
-            <p>• state panels are consistent before real data arrives</p>
-            <p>• future feature work can focus on composition, not layout glue</p>
+            <p>• shared navigation and framing are already in place</p>
+            <p>• state panels will stay visually consistent</p>
+            <p>• the route is ready whenever the feature work starts</p>
           </div>
         </cc-card>
 
         <div class="space-y-6">
           <cc-state-panel
             kind="empty"
-            title="Feature migration not started yet"
-            message="This page is intentionally waiting for its follow-on issue so #69 can stay focused on shared shell and primitive work."
+            title="Feature not implemented yet"
+            message="There is not real data behind this page yet."
           ></cc-state-panel>
 
-          <cc-card eyebrow="Next step" title="Back to the scaffold home" tone="muted" [compact]="true">
+          <cc-card eyebrow="Next step" title="Back to Home" tone="muted" [compact]="true">
             <a routerLink="/" class="inline-flex rounded-full border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-sm font-medium text-amber-200 transition hover:border-amber-300/60 hover:bg-amber-300/15">
-              Return to overview
+              Return to Home
             </a>
           </cc-card>
         </div>

--- a/frontend/src/app/layout/app-shell.component.ts
+++ b/frontend/src/app/layout/app-shell.component.ts
@@ -2,28 +2,25 @@ import { Component, input } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { NavItem } from '../shared/models/nav-item';
-import { PillComponent } from '../shared/ui/pill.component';
 import { ThemeToggleComponent } from './theme-toggle.component';
 
 @Component({
   selector: 'app-shell',
-  imports: [RouterLink, RouterLinkActive, RouterOutlet, PillComponent, ThemeToggleComponent],
+  imports: [RouterLink, RouterLinkActive, RouterOutlet, ThemeToggleComponent],
   template: `
     <div class="min-h-screen cc-app-bg text-[var(--cc-text)]">
       <header class="border-b border-[var(--cc-border)] bg-[var(--cc-header)]/95 backdrop-blur">
         <div class="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-6 lg:px-8">
           <div class="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
             <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-[var(--cc-text-soft)]">command.center rewrite</p>
-              <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">Angular now covers the full dashboard</h1>
+              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-[var(--cc-text-soft)]">command.center</p>
+              <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">Command Center</h1>
               <p class="mt-3 max-w-3xl text-sm leading-7 text-[var(--cc-text-muted)]">
-                The rewrite now includes Angular versions of the major command-center views, backed by the shared shell, data layer, and interaction state services.
+                GitHub, notes, tasks, calendar, analytics, and runtime status in one place.
               </p>
             </div>
 
             <div class="flex flex-wrap items-center gap-3">
-              <cc-pill tone="accent">Issue #72</cc-pill>
-              <cc-pill>Full Angular dashboard</cc-pill>
               <app-theme-toggle></app-theme-toggle>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove rewrite and migration copy from the Angular app shell and Home view
- replace leftover rollout badges/text with normal product wording
- clean up the shared placeholder page so it does not talk about the migration either

## Testing
- npm test
