### PR TITLE
Remove rollout copy from secondary views

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -23,7 +23,7 @@ export const routes: Routes = [
     title: 'Urgent Issues',
     data: {
       priority: 'urgent',
-      eyebrow: 'Layer 1',
+      eyebrow: 'Issues',
       title: 'Urgent Issues',
       subtitle: 'Critical and bug-heavy work that needs the fastest attention.',
     },
@@ -34,7 +34,7 @@ export const routes: Routes = [
     title: 'Active Issues',
     data: {
       priority: 'active',
-      eyebrow: 'Layer 1',
+      eyebrow: 'Issues',
       title: 'Active Issues',
       subtitle: 'In-progress work and the main queue of issues that are currently active.',
     },
@@ -45,7 +45,7 @@ export const routes: Routes = [
     title: 'Backlog Issues',
     data: {
       priority: 'backlog',
-      eyebrow: 'Layer 1',
+      eyebrow: 'Issues',
       title: 'Backlog Issues',
       subtitle: 'Deferred work and the longer queue waiting behind the current focus.',
     },

--- a/frontend/src/app/features/analytics/analytics.page.ts
+++ b/frontend/src/app/features/analytics/analytics.page.ts
@@ -2,16 +2,14 @@ import { Component, computed, inject } from '@angular/core';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { ViewShellComponent } from '../../layout/view-shell.component';
-import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-analytics-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Pass 2" title="Analytics" subtitle="Angular analytics view with shared resource loading, summary metrics, and site table presentation." [meta]="meta()">
+    <app-view-shell eyebrow="Analytics" title="Analytics" subtitle="Traffic summary and site-level metrics." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="warning">Angular secondary view</cc-pill>
         <button type="button" (click)="analytics.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
       </div>
 

--- a/frontend/src/app/features/calendar/calendar.page.ts
+++ b/frontend/src/app/features/calendar/calendar.page.ts
@@ -4,16 +4,14 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { CalendarEvent } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
-import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-calendar-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Pass 1" title="Calendar" subtitle="Upcoming events now run through Angular with shared event cards and pinning." [meta]="meta()">
+    <app-view-shell eyebrow="Calendar" title="Calendar" subtitle="Upcoming events with quick pinning." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="info">Angular secondary view</cc-pill>
         <button type="button" (click)="calendar.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
       </div>
 

--- a/frontend/src/app/features/infra/infra.page.ts
+++ b/frontend/src/app/features/infra/infra.page.ts
@@ -9,9 +9,8 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   selector: 'app-infra-page',
   imports: [ViewShellComponent, PillComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Pass 2" title="Infrastructure" subtitle="Angular Infra view with summary stats, process cards, and degraded-state handling." [meta]="meta()">
+    <app-view-shell eyebrow="Infrastructure" title="Infrastructure" subtitle="Process status, uptime, restarts, and degraded-state handling." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="warning">Angular secondary view</cc-pill>
         <button type="button" (click)="infra.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
       </div>
 

--- a/frontend/src/app/features/issues/issue-list.page.ts
+++ b/frontend/src/app/features/issues/issue-list.page.ts
@@ -5,16 +5,14 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { IssueItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
-import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-issue-list-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, StatePanelComponent],
   template: `
     <app-view-shell [eyebrow]="eyebrow()" [title]="title()" [subtitle]="subtitle()" [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="info">Angular issue view</cc-pill>
         <button
           type="button"
           (click)="issues.refresh()"

--- a/frontend/src/app/features/notes/notes.page.ts
+++ b/frontend/src/app/features/notes/notes.page.ts
@@ -9,9 +9,8 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   selector: 'app-notes-page',
   imports: [ViewShellComponent, PillComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Pass 1" title="Notes" subtitle="Daily note, decision log, and latest standup presentation now run from Angular." [meta]="meta()">
+    <app-view-shell eyebrow="Notes" title="Notes" subtitle="Daily note, recent decisions, and latest standup context." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="info">Angular secondary view</cc-pill>
         <button type="button" (click)="refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
       </div>
 

--- a/frontend/src/app/features/prs/prs.page.ts
+++ b/frontend/src/app/features/prs/prs.page.ts
@@ -4,16 +4,14 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { PullRequestItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
-import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-prs-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Layer 1" title="Pull Requests" subtitle="Angular PR view with search, pinning, and the shared data/resource layer behind it." [meta]="meta()">
+    <app-view-shell eyebrow="Review" title="Pull Requests" subtitle="Open pull requests with search, pinning, and review status." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="info">Angular PR view</cc-pill>
         <button type="button" (click)="prs.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search PRs…" />
       </div>

--- a/frontend/src/app/features/repos/repos.page.ts
+++ b/frontend/src/app/features/repos/repos.page.ts
@@ -5,16 +5,14 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { RepoSummary } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
-import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-repos-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Pass 1" title="Repositories" subtitle="Repository health, open issue counts, and repo-to-issues handoff now run from Angular." [meta]="meta()">
+    <app-view-shell eyebrow="Repositories" title="Repositories" subtitle="Repository health, open issue counts, and quick handoff into issue views." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="info">Angular secondary view</cc-pill>
         <button type="button" (click)="repos.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search repos…" />
       </div>

--- a/frontend/src/app/features/tasks/done.page.ts
+++ b/frontend/src/app/features/tasks/done.page.ts
@@ -2,16 +2,14 @@ import { Component, computed, inject, signal } from '@angular/core';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { ViewShellComponent } from '../../layout/view-shell.component';
-import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-done-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Layer 1" title="Completed Tasks" subtitle="Angular done view for recently completed Obsidian tasks." [meta]="meta()">
+    <app-view-shell eyebrow="Tasks" title="Completed Tasks" subtitle="Recently completed tasks from Obsidian." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="info">Angular done view</cc-pill>
         <button type="button" (click)="tasks.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search completed tasks…" />
       </div>

--- a/frontend/src/app/features/tasks/tasks.page.ts
+++ b/frontend/src/app/features/tasks/tasks.page.ts
@@ -4,16 +4,14 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { TaskItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
-import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-tasks-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, StatePanelComponent],
   template: `
-    <app-view-shell eyebrow="Layer 1" title="Tasks" subtitle="Angular task view with search, pinning, and shared Obsidian-backed task data." [meta]="meta()">
+    <app-view-shell eyebrow="Tasks" title="Tasks" subtitle="Open tasks from your Obsidian task lists, with search and pinning." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <cc-pill tone="info">Angular task view</cc-pill>
         <button type="button" (click)="tasks.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search tasks…" />
       </div>


### PR DESCRIPTION
## Summary
- remove the leftover Angular rollout pills from the secondary views
- replace phase and migration-era eyebrow/subtitle copy with normal product wording
- keep the secondary view headers focused on the actual content instead of the rewrite process

## Testing
- npm test
