### PR TITLE
TailAdmin-inspired visual refresh for command-center

### DIFF
--- a/frontend/src/app/features/analytics/analytics.page.ts
+++ b/frontend/src/app/features/analytics/analytics.page.ts
@@ -27,7 +27,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Avg Bounce</div><div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ averageBounce() }}%</div></div>
         </section>
 
-        <section class="overflow-hidden rounded-[28px] border border-white/10 bg-slate-950/65 shadow-[0_30px_90px_-48px_rgba(15,23,42,1)] backdrop-blur-xl">
+        <section class="cc-table-shell">
           <div class="overflow-x-auto">
             <table class="min-w-full border-collapse text-sm">
               <thead>

--- a/frontend/src/app/features/analytics/analytics.page.ts
+++ b/frontend/src/app/features/analytics/analytics.page.ts
@@ -10,7 +10,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Analytics" title="Analytics" subtitle="Traffic summary and site-level metrics." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="analytics.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <button type="button" (click)="analytics.refresh()" class="cc-action-button">Refresh</button>
       </div>
 
       @if (analytics.isLoading()) {
@@ -21,13 +21,13 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
         <cc-state-panel kind="empty" title="No analytics data" message="No analytics site rows were returned for the current range."></cc-state-panel>
       } @else {
         <section class="grid gap-4 md:grid-cols-4">
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Page Views</div><div class="mt-3 text-3xl font-semibold text-amber-300">{{ analytics.data()!.totals.pageviews.toLocaleString() }}</div></div>
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Unique Visitors</div><div class="mt-3 text-3xl font-semibold text-sky-300">{{ analytics.data()!.totals.visitors.toLocaleString() }}</div></div>
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Sessions</div><div class="mt-3 text-3xl font-semibold text-emerald-300">{{ analytics.data()!.totals.visits.toLocaleString() }}</div></div>
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Avg Bounce</div><div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ averageBounce() }}%</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Page Views</div><div class="mt-3 text-3xl font-semibold text-amber-300">{{ analytics.data()!.totals.pageviews.toLocaleString() }}</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Unique Visitors</div><div class="mt-3 text-3xl font-semibold text-sky-300">{{ analytics.data()!.totals.visitors.toLocaleString() }}</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Sessions</div><div class="mt-3 text-3xl font-semibold text-emerald-300">{{ analytics.data()!.totals.visits.toLocaleString() }}</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Avg Bounce</div><div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ averageBounce() }}%</div></div>
         </section>
 
-        <section class="overflow-hidden rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)]">
+        <section class="overflow-hidden rounded-[28px] border border-white/10 bg-slate-950/65 shadow-[0_30px_90px_-48px_rgba(15,23,42,1)] backdrop-blur-xl">
           <div class="overflow-x-auto">
             <table class="min-w-full border-collapse text-sm">
               <thead>
@@ -45,8 +45,8 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                   <tr class="border-b border-[var(--cc-border)] align-top">
                     <td class="px-5 py-4">
                       <div class="font-semibold text-[var(--cc-text)]">{{ site.name }}</div>
-                      <a [href]="'https://' + site.domain" target="_blank" class="mt-1 inline-flex text-xs text-[var(--cc-text-soft)]">{{ site.domain }}</a>
-                      <div class="mt-3 h-1.5 w-28 overflow-hidden rounded-full bg-[var(--cc-surface-muted)]">
+                      <a [href]="'https://' + site.domain" target="_blank" class="mt-1 inline-flex text-xs text-[var(--cc-text-soft)] transition hover:text-[var(--cc-text)]">{{ site.domain }}</a>
+                      <div class="mt-3 h-1.5 w-28 overflow-hidden rounded-full bg-white/10">
                         <div class="h-full rounded-full bg-amber-300" [style.width.%]="shareOfPageviews(site.pageviews)"></div>
                       </div>
                     </td>

--- a/frontend/src/app/features/calendar/calendar.page.ts
+++ b/frontend/src/app/features/calendar/calendar.page.ts
@@ -12,7 +12,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Calendar" title="Calendar" subtitle="Upcoming events with quick pinning." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="calendar.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <button type="button" (click)="calendar.refresh()" class="cc-action-button">Refresh</button>
       </div>
 
       @if (calendar.isLoading()) {
@@ -26,7 +26,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           @if (pinnedItems().length) {
             <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
             @for (event of pinnedItems(); track eventKey(event)) {
-              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <article class="cc-list-card p-5">
                 <div class="flex items-start justify-between gap-4">
                   <div>
                     <div class="text-base font-semibold text-[var(--cc-text)]">{{ event.title }}</div>
@@ -35,7 +35,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                       <div class="mt-2 text-xs text-[var(--cc-text-soft)]">📍 {{ event.location }}</div>
                     }
                   </div>
-                  <button type="button" (click)="togglePinned(event)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                  <button type="button" (click)="togglePinned(event)" class="cc-small-button cc-small-button-accent">Unpin</button>
                 </div>
               </article>
             }
@@ -45,7 +45,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           }
 
           @for (event of unpinnedItems(); track eventKey(event)) {
-            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm" [class.opacity-60]="isPast(event)">
+            <article class="cc-list-card p-5" [class.opacity-60]="isPast(event)">
               <div class="flex items-start justify-between gap-4">
                 <div>
                   <div class="text-base font-semibold text-[var(--cc-text)]">{{ event.title }}</div>
@@ -54,7 +54,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                     <div class="mt-2 text-xs text-[var(--cc-text-soft)]">📍 {{ event.location }}</div>
                   }
                 </div>
-                <button type="button" (click)="togglePinned(event)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+                <button type="button" (click)="togglePinned(event)" class="cc-small-button">Pin</button>
               </div>
             </article>
           }

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -80,7 +80,7 @@ interface PinnedHomeItem {
         </div>
 
         @if (composerOpen()) {
-          <div class="mt-4 grid gap-3 rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4 md:grid-cols-[1fr_180px_auto_auto]">
+          <div class="cc-list-card mt-4 grid gap-3 p-4 md:grid-cols-[1fr_180px_auto_auto]">
             <input [value]="reminderText()" (input)="reminderText.set($any($event.target).value)" (keydown)="onReminderKeydown($event)" class="cc-input rounded-xl px-4 py-3 text-sm" placeholder="What do you need to remember?" />
             <input [value]="reminderDue() || ''" (input)="reminderDue.set($any($event.target).value || null)" type="date" class="cc-input rounded-xl px-4 py-3 text-sm" />
             <button type="button" (click)="saveReminder()" class="cc-small-button cc-small-button-accent rounded-xl px-4 py-3 text-sm">{{ editingReminderId() ? 'Save' : 'Add' }}</button>
@@ -93,7 +93,7 @@ interface PinnedHomeItem {
             <cc-state-panel kind="empty" title="No reminders yet" message="Add one above, or press N while on Home to capture a quick reminder."></cc-state-panel>
           } @else {
             @for (reminder of reminders.items(); track reminder.id) {
-              <div class="flex items-center gap-3 rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-3">
+              <div class="cc-list-card flex items-center gap-3 px-4 py-3">
                 <button type="button" (click)="completeReminder(reminder.id)" class="h-5 w-5 rounded-full border border-[var(--cc-border)]"></button>
                 <div class="min-w-0 flex-1">
                   <div class="truncate text-sm font-medium text-[var(--cc-text)]">{{ reminder.text }}</div>
@@ -125,7 +125,7 @@ interface PinnedHomeItem {
         @if (hiddenSections().length) {
           <div class="mt-4 flex flex-wrap gap-2">
             @for (sectionId of hiddenSections(); track sectionId) {
-              <button type="button" (click)="homeLayout.restore(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Show {{ sectionLabel(sectionId) }}</button>
+              <button type="button" (click)="homeLayout.restore(sectionId)" class="cc-small-button">Show {{ sectionLabel(sectionId) }}</button>
             }
           </div>
         }
@@ -140,12 +140,12 @@ interface PinnedHomeItem {
                   <div class="text-lg font-semibold tracking-tight text-[var(--cc-text)]">{{ sectionLabel(sectionId) }}</div>
                 </div>
                 <div class="flex flex-wrap justify-end gap-2">
-                  <button type="button" (click)="homeLayout.toggleCollapsed(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ isSectionCollapsed(sectionId) ? 'Expand' : 'Collapse' }}</button>
+                  <button type="button" (click)="homeLayout.toggleCollapsed(sectionId)" class="cc-small-button">{{ isSectionCollapsed(sectionId) ? 'Expand' : 'Collapse' }}</button>
                   @if (homeLayout.customizeMode()) {
-                    <button type="button" (click)="homeLayout.pinToTop(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Top</button>
-                    <button type="button" (click)="homeLayout.move(sectionId, -1)" [disabled]="index === 0" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)] disabled:opacity-50">↑</button>
-                    <button type="button" (click)="homeLayout.move(sectionId, 1)" [disabled]="index === homeLayout.layout().order.length - 1" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)] disabled:opacity-50">↓</button>
-                    <button type="button" (click)="homeLayout.toggleHidden(sectionId)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Hide</button>
+                    <button type="button" (click)="homeLayout.pinToTop(sectionId)" class="cc-small-button">Top</button>
+                    <button type="button" (click)="homeLayout.move(sectionId, -1)" [disabled]="index === 0" class="cc-small-button disabled:opacity-50">↑</button>
+                    <button type="button" (click)="homeLayout.move(sectionId, 1)" [disabled]="index === homeLayout.layout().order.length - 1" class="cc-small-button disabled:opacity-50">↓</button>
+                    <button type="button" (click)="homeLayout.toggleHidden(sectionId)" class="cc-small-button">Hide</button>
                   }
                 </div>
               </div>
@@ -159,14 +159,14 @@ interface PinnedHomeItem {
                       } @else {
                         <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                           @for (item of pinnedHomeItems(); track item.type + ':' + item.title + ':' + item.meta) {
-                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                            <div class="cc-list-card p-4">
                               <div class="flex items-start justify-between gap-3">
                                 <div class="min-w-0 flex-1">
                                   <div class="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">{{ item.type }}</div>
                                   <div class="mt-2 truncate text-sm font-semibold text-[var(--cc-text)]">{{ item.title }}</div>
                                   <div class="mt-2 text-xs leading-5 text-[var(--cc-text-soft)]">{{ item.meta }}</div>
                                 </div>
-                                <button type="button" (click)="item.unpin()" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">×</button>
+                                <button type="button" (click)="item.unpin()" class="cc-small-button cc-small-button-danger">×</button>
                               </div>
                               @if (item.externalUrl) {
                                 <a [href]="item.externalUrl" target="_blank" class="mt-4 inline-flex text-xs font-semibold uppercase tracking-[0.18em] text-amber-300">Open</a>
@@ -188,13 +188,13 @@ interface PinnedHomeItem {
                       } @else {
                         <div class="space-y-3">
                           @for (event of upcomingEvents(); track eventKey(event)) {
-                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                            <div class="cc-list-card p-4">
                               <div class="flex items-start justify-between gap-3">
                                 <div>
                                   <div class="text-sm font-semibold text-[var(--cc-text)]">{{ event.title }}</div>
                                   <div class="mt-2 text-xs leading-5 text-[var(--cc-text-soft)]">{{ eventDateLabel(event) }} · {{ eventTimeLabel(event) }} · {{ event.calendar }}</div>
                                 </div>
-                                <button type="button" (click)="togglePinnedEvent(event)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ pins.isPinned('event', eventKey(event)) ? 'Unpin' : 'Pin' }}</button>
+                                <button type="button" (click)="togglePinnedEvent(event)" class="cc-small-button">{{ pins.isPinned('event', eventKey(event)) ? 'Unpin' : 'Pin' }}</button>
                               </div>
                             </div>
                           }
@@ -211,15 +211,15 @@ interface PinnedHomeItem {
                       } @else {
                         <div class="space-y-3">
                           @for (issue of homeIssues(); track issueKey(issue)) {
-                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                            <div class="cc-list-card p-4">
                               <div class="flex items-start justify-between gap-3">
                                 <div>
                                   <div class="text-sm font-semibold text-[var(--cc-text)]">{{ issue.title }}</div>
                                   <div class="mt-2 text-xs leading-5 text-[var(--cc-text-soft)]">{{ issue.repo }} · #{{ issue.number }} · {{ timeAgo(issue.createdAt) }}</div>
                                 </div>
                                 <div class="flex items-center gap-2">
-                                  <button type="button" (click)="togglePinnedIssue(issue)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ pins.isPinned('issue', issueKey(issue)) ? 'Unpin' : 'Pin' }}</button>
-                                  <button type="button" (click)="go('/issues/' + issueRoute(issue.priority))" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">View</button>
+                                  <button type="button" (click)="togglePinnedIssue(issue)" class="cc-small-button">{{ pins.isPinned('issue', issueKey(issue)) ? 'Unpin' : 'Pin' }}</button>
+                                  <button type="button" (click)="go('/issues/' + issueRoute(issue.priority))" class="cc-small-button cc-small-button-accent">View</button>
                                 </div>
                               </div>
                             </div>
@@ -237,7 +237,7 @@ interface PinnedHomeItem {
                       } @else {
                         <div class="space-y-3">
                           @for (task of homeTasks(); track taskKey(task)) {
-                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                            <div class="cc-list-card p-4">
                               <div class="flex items-start justify-between gap-3">
                                 <div>
                                   <div class="text-sm font-semibold text-[var(--cc-text)]">{{ task.title }}</div>
@@ -247,7 +247,7 @@ interface PinnedHomeItem {
                                     @if (task.due) { · 📅 {{ task.due }} }
                                   </div>
                                 </div>
-                                <button type="button" (click)="togglePinnedTask(task)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">{{ pins.isPinned('task', taskKey(task)) ? 'Unpin' : 'Pin' }}</button>
+                                <button type="button" (click)="togglePinnedTask(task)" class="cc-small-button">{{ pins.isPinned('task', taskKey(task)) ? 'Unpin' : 'Pin' }}</button>
                               </div>
                             </div>
                           }
@@ -262,7 +262,7 @@ interface PinnedHomeItem {
                       } @else if (!notes.data()?.dailyNote) {
                         <cc-state-panel kind="empty" title="No recent daily note" message="No recent daily note was found in the configured Obsidian paths."></cc-state-panel>
                       } @else {
-                        <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5">
+                        <div class="cc-list-card p-5">
                           <div class="flex items-center justify-between gap-4">
                             <div class="text-sm font-semibold text-[var(--cc-text)]">{{ notes.data()!.dailyNote!.date }}</div>
                             <cc-pill tone="info">{{ notes.data()!.dailyNote!.isToday ? 'Today' : 'Most recent' }}</cc-pill>
@@ -285,7 +285,7 @@ interface PinnedHomeItem {
                             <cc-pill tone="info">{{ standup.data()!.isToday ? 'Today' : standup.data()!.date }}</cc-pill>
                           </div>
                           @for (section of standup.data()!.sections; track section.repo) {
-                            <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                            <div class="cc-list-card p-4">
                               <div class="flex items-center justify-between gap-3">
                                 <div class="text-sm font-semibold text-[var(--cc-text)]">{{ section.repo }}</div>
                                 <div class="text-xs text-[var(--cc-text-soft)]">{{ section.stats }}</div>

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -31,34 +31,34 @@ interface PinnedHomeItem {
       [meta]="homeMeta()"
     >
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="refreshAll()" [disabled]="refreshingAll()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)] disabled:cursor-not-allowed disabled:opacity-60">
+        <button type="button" (click)="refreshAll()" [disabled]="refreshingAll()" class="cc-action-button disabled:cursor-not-allowed disabled:opacity-60">
           {{ refreshingAll() ? 'Refreshing…' : 'Refresh sources' }}
         </button>
       </div>
 
       <cc-card eyebrow="Today" title="command.center" [description]="tagline()" tone="highlight" [compact]="true">
         <section class="grid gap-4 lg:grid-cols-5">
-          <button type="button" (click)="go('/issues/urgent')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-rose-300/40">
+          <button type="button" (click)="go('/issues/urgent')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Urgent</div>
             <div class="mt-3 text-3xl font-semibold text-rose-300">{{ issues.data()?.counts?.urgent ?? 0 }}</div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">bugs and critical work</div>
           </button>
-          <button type="button" (click)="go('/issues/active')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-amber-300/40">
+          <button type="button" (click)="go('/issues/active')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Active</div>
             <div class="mt-3 text-3xl font-semibold text-amber-300">{{ issues.data()?.counts?.active ?? 0 }}</div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">in-progress issues</div>
           </button>
-          <button type="button" (click)="go('/issues/backlog')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-slate-300/40">
+          <button type="button" (click)="go('/issues/backlog')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Backlog</div>
             <div class="mt-3 text-3xl font-semibold text-slate-300">{{ issues.data()?.counts?.deferred ?? 0 }}</div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ issues.data()?.total ?? 0 }} total open</div>
           </button>
-          <button type="button" (click)="go('/tasks')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-fuchsia-300/40">
+          <button type="button" (click)="go('/tasks')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Tasks</div>
             <div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ tasks.data()?.open?.length ?? 0 }}</div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">open in Obsidian</div>
           </button>
-          <button type="button" (click)="go('/infra')" class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5 text-left transition hover:border-emerald-300/40">
+          <button type="button" (click)="go('/infra')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Infra</div>
             @if (infra.hasData()) {
               <div class="mt-3 text-3xl font-semibold text-emerald-300">{{ onlineServices() }}<span class="text-base font-medium text-[var(--cc-text-soft)]">/{{ infra.data()?.length ?? 0 }}</span></div>
@@ -76,15 +76,15 @@ interface PinnedHomeItem {
           <div>
             <p class="text-sm text-[var(--cc-text-muted)]">Quick capture for things you do not want falling through the cracks.</p>
           </div>
-          <button type="button" (click)="openReminderComposer()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">＋ Add</button>
+          <button type="button" (click)="openReminderComposer()" class="cc-action-button">＋ Add</button>
         </div>
 
         @if (composerOpen()) {
           <div class="mt-4 grid gap-3 rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4 md:grid-cols-[1fr_180px_auto_auto]">
-            <input [value]="reminderText()" (input)="reminderText.set($any($event.target).value)" (keydown)="onReminderKeydown($event)" class="rounded-xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-4 py-3 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="What do you need to remember?" />
-            <input [value]="reminderDue() || ''" (input)="reminderDue.set($any($event.target).value || null)" type="date" class="rounded-xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-4 py-3 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" />
-            <button type="button" (click)="saveReminder()" class="rounded-xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-3 text-sm font-medium text-emerald-200">{{ editingReminderId() ? 'Save' : 'Add' }}</button>
-            <button type="button" (click)="cancelReminderEdit()" class="rounded-xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-4 py-3 text-sm font-medium text-[var(--cc-text-muted)]">Cancel</button>
+            <input [value]="reminderText()" (input)="reminderText.set($any($event.target).value)" (keydown)="onReminderKeydown($event)" class="cc-input rounded-xl px-4 py-3 text-sm" placeholder="What do you need to remember?" />
+            <input [value]="reminderDue() || ''" (input)="reminderDue.set($any($event.target).value || null)" type="date" class="cc-input rounded-xl px-4 py-3 text-sm" />
+            <button type="button" (click)="saveReminder()" class="cc-small-button cc-small-button-accent rounded-xl px-4 py-3 text-sm">{{ editingReminderId() ? 'Save' : 'Add' }}</button>
+            <button type="button" (click)="cancelReminderEdit()" class="cc-small-button rounded-xl px-4 py-3 text-sm">Cancel</button>
           </div>
         }
 
@@ -101,8 +101,8 @@ interface PinnedHomeItem {
                     <div class="mt-1 text-xs text-[var(--cc-text-soft)]">📅 {{ reminder.due }}</div>
                   }
                 </div>
-                <button type="button" (click)="editReminder(reminder)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Edit</button>
-                <button type="button" (click)="dismissReminder(reminder.id)" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">Dismiss</button>
+                <button type="button" (click)="editReminder(reminder)" class="cc-small-button">Edit</button>
+                <button type="button" (click)="dismissReminder(reminder.id)" class="cc-small-button cc-small-button-danger">Dismiss</button>
               </div>
             }
           }
@@ -116,9 +116,9 @@ interface PinnedHomeItem {
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ layoutSummary() }}</div>
           </div>
           <div class="flex flex-wrap gap-3">
-            <button type="button" (click)="homeLayout.toggleCompact()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)]">{{ homeLayout.layout().compact ? 'Compact on' : 'Compact mode' }}</button>
-            <button type="button" (click)="homeLayout.toggleCustomize()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)]">{{ homeLayout.customizeMode() ? 'Done customizing' : 'Customize' }}</button>
-            <button type="button" (click)="homeLayout.reset()" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)]">Reset layout</button>
+            <button type="button" (click)="homeLayout.toggleCompact()" class="cc-action-button">{{ homeLayout.layout().compact ? 'Compact on' : 'Compact mode' }}</button>
+            <button type="button" (click)="homeLayout.toggleCustomize()" class="cc-action-button">{{ homeLayout.customizeMode() ? 'Done customizing' : 'Customize' }}</button>
+            <button type="button" (click)="homeLayout.reset()" class="cc-action-button">Reset layout</button>
           </div>
         </div>
 

--- a/frontend/src/app/features/infra/infra.page.ts
+++ b/frontend/src/app/features/infra/infra.page.ts
@@ -40,9 +40,9 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
               </div>
 
               <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Uptime</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatUptime(process.uptime) }}</div></div>
-                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Memory</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatMemory(process.memory) }}</div></div>
-                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Restarts</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ process.restarts }}</div></div>
+                <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Uptime</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatUptime(process.uptime) }}</div></div>
+                <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Memory</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatMemory(process.memory) }}</div></div>
+                <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Restarts</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ process.restarts }}</div></div>
               </div>
             </article>
           }

--- a/frontend/src/app/features/infra/infra.page.ts
+++ b/frontend/src/app/features/infra/infra.page.ts
@@ -11,7 +11,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Infrastructure" title="Infrastructure" subtitle="Process status, uptime, restarts, and degraded-state handling." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="infra.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <button type="button" (click)="infra.refresh()" class="cc-action-button">Refresh</button>
       </div>
 
       @if (infra.isLoading()) {
@@ -22,15 +22,15 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
         <cc-state-panel kind="empty" title="No process data" message="No infrastructure processes were returned for the current environment."></cc-state-panel>
       } @else {
         <section class="grid gap-4 md:grid-cols-4">
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Total</div><div class="mt-3 text-3xl font-semibold text-[var(--cc-text)]">{{ infra.data()!.length }}</div></div>
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Online</div><div class="mt-3 text-3xl font-semibold text-emerald-300">{{ onlineCount() }}</div></div>
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Down</div><div class="mt-3 text-3xl font-semibold text-rose-300">{{ downCount() }}</div></div>
-          <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Restarts</div><div class="mt-3 text-3xl font-semibold text-amber-300">{{ restartCount() }}</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Total</div><div class="mt-3 text-3xl font-semibold text-[var(--cc-text)]">{{ infra.data()!.length }}</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Online</div><div class="mt-3 text-3xl font-semibold text-emerald-300">{{ onlineCount() }}</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Down</div><div class="mt-3 text-3xl font-semibold text-rose-300">{{ downCount() }}</div></div>
+          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Restarts</div><div class="mt-3 text-3xl font-semibold text-amber-300">{{ restartCount() }}</div></div>
         </section>
 
         <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
           @for (process of infra.data()!; track process.name + ':' + process.id) {
-            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+            <article class="cc-list-card p-5">
               <div class="flex items-start justify-between gap-4">
                 <div>
                   <div class="text-base font-semibold text-[var(--cc-text)]">{{ process.name }}</div>
@@ -40,9 +40,9 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
               </div>
 
               <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Uptime</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatUptime(process.uptime) }}</div></div>
-                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Memory</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatMemory(process.memory) }}</div></div>
-                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Restarts</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ process.restarts }}</div></div>
+                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Uptime</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatUptime(process.uptime) }}</div></div>
+                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Memory</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ formatMemory(process.memory) }}</div></div>
+                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Restarts</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ process.restarts }}</div></div>
               </div>
             </article>
           }

--- a/frontend/src/app/features/issues/issue-list.page.ts
+++ b/frontend/src/app/features/issues/issue-list.page.ts
@@ -16,14 +16,14 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
         <button
           type="button"
           (click)="issues.refresh()"
-          class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]"
+          class="cc-action-button"
         >
           Refresh
         </button>
         <input
           [value]="searchText()"
           (input)="searchText.set($any($event.target).value)"
-          class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40"
+          class="cc-input min-w-64 px-4 py-2 text-sm"
           placeholder="Search issues…"
         />
       </div>
@@ -46,24 +46,24 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
               <span>Pinned</span>
             </div>
             @for (issue of pinnedItems(); track issue.repoFull + '#' + issue.number) {
-              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <article class="cc-list-card p-5">
                 <div class="flex items-start justify-between gap-4">
                   <div class="min-w-0">
-                    <a [href]="issue.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ issue.title }}</a>
+                    <a [href]="issue.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-indigo-300">{{ issue.title }}</a>
                     <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
-                      <span class="font-semibold text-amber-300">{{ issue.repo }}</span>
+                      <span class="font-semibold text-indigo-300">{{ issue.repo }}</span>
                       <span>#{{ issue.number }}</span>
                       <span>{{ timeAgo(issue.createdAt) }}</span>
                     </div>
                     <div class="mt-3 flex flex-wrap gap-2">
                       @for (label of issue.labels.slice(0, 3); track label.name) {
-                        <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 text-xs font-medium text-[var(--cc-text-muted)]">{{ label.name }}</span>
+                        <span class="cc-label-pill">{{ label.name }}</span>
                       }
                     </div>
                   </div>
                   <div class="flex shrink-0 items-center gap-2">
-                    <button type="button" (click)="togglePinned(issue)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
-                    <button type="button" (click)="close(issue)" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">Close</button>
+                    <button type="button" (click)="togglePinned(issue)" class="cc-small-button cc-small-button-accent">Unpin</button>
+                    <button type="button" (click)="close(issue)" class="cc-small-button cc-small-button-danger">Close</button>
                   </div>
                 </div>
               </article>
@@ -74,24 +74,24 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           }
 
           @for (issue of unpinnedItems(); track issue.repoFull + '#' + issue.number) {
-            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+            <article class="cc-list-card p-5">
               <div class="flex items-start justify-between gap-4">
                 <div class="min-w-0">
-                  <a [href]="issue.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ issue.title }}</a>
+                  <a [href]="issue.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-indigo-300">{{ issue.title }}</a>
                   <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
-                    <span class="font-semibold text-amber-300">{{ issue.repo }}</span>
+                    <span class="font-semibold text-indigo-300">{{ issue.repo }}</span>
                     <span>#{{ issue.number }}</span>
                     <span>{{ timeAgo(issue.createdAt) }}</span>
                   </div>
                   <div class="mt-3 flex flex-wrap gap-2">
                     @for (label of issue.labels.slice(0, 3); track label.name) {
-                      <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 text-xs font-medium text-[var(--cc-text-muted)]">{{ label.name }}</span>
+                      <span class="cc-label-pill">{{ label.name }}</span>
                     }
                   </div>
                 </div>
                 <div class="flex shrink-0 items-center gap-2">
-                  <button type="button" (click)="togglePinned(issue)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
-                  <button type="button" (click)="close(issue)" class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs font-semibold text-rose-200">Close</button>
+                  <button type="button" (click)="togglePinned(issue)" class="cc-small-button">Pin</button>
+                  <button type="button" (click)="close(issue)" class="cc-small-button cc-small-button-danger">Close</button>
                 </div>
               </div>
             </article>

--- a/frontend/src/app/features/notes/notes.page.ts
+++ b/frontend/src/app/features/notes/notes.page.ts
@@ -32,7 +32,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                 <div class="space-y-4">
                   <div class="text-sm text-[var(--cc-text-muted)]">{{ standup.data()!.title }}</div>
                   @for (section of standup.data()!.sections; track section.repo) {
-                    <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                    <div class="cc-list-card p-4">
                       <div class="flex items-center justify-between gap-4">
                         <div class="text-sm font-semibold text-[var(--cc-text)]">{{ section.repo }}</div>
                         <div class="text-xs text-[var(--cc-text-soft)]">{{ section.stats }}</div>
@@ -61,7 +61,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
               } @else if (!notes.data()?.dailyNote) {
                 <cc-state-panel kind="empty" title="No recent daily note" message="No recent daily note was found in the configured Obsidian paths."></cc-state-panel>
               } @else {
-                <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-5">
+                <div class="cc-list-card p-5">
                   <div class="flex items-center justify-between gap-4">
                     <div class="text-sm font-semibold text-[var(--cc-text)]">{{ notes.data()!.dailyNote!.date }}</div>
                     <cc-pill tone="info">{{ notes.data()!.dailyNote!.isToday ? 'Today' : 'Most recent' }}</cc-pill>
@@ -84,7 +84,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
               } @else {
                 <div class="space-y-3">
                   @for (decision of notes.data()!.decisions; track decision.title + decision.date) {
-                    <div class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] p-4">
+                    <div class="cc-list-card p-4">
                       <div class="flex items-center justify-between gap-3">
                         <div class="text-sm font-semibold text-[var(--cc-text)]">{{ decision.title }}</div>
                         <div class="text-xs text-[var(--cc-text-soft)]">{{ decision.date }}</div>

--- a/frontend/src/app/features/notes/notes.page.ts
+++ b/frontend/src/app/features/notes/notes.page.ts
@@ -11,7 +11,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Notes" title="Notes" subtitle="Daily note, recent decisions, and latest standup context." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
+        <button type="button" (click)="refresh()" class="cc-action-button">Refresh</button>
       </div>
 
       <section class="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">

--- a/frontend/src/app/features/prs/prs.page.ts
+++ b/frontend/src/app/features/prs/prs.page.ts
@@ -12,8 +12,8 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Review" title="Pull Requests" subtitle="Open pull requests with search, pinning, and review status." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="prs.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
-        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search PRs…" />
+        <button type="button" (click)="prs.refresh()" class="cc-action-button">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search PRs…" />
       </div>
 
       @if (prs.isLoading()) {
@@ -27,10 +27,10 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           @if (pinnedItems().length) {
             <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
             @for (pr of pinnedItems(); track pr.repoFull + '#' + pr.number) {
-              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <article class="cc-list-card p-5">
                 <div class="flex items-start justify-between gap-4">
                   <div class="min-w-0">
-                    <a [href]="pr.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ pr.title }}</a>
+                    <a [href]="pr.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-indigo-300">{{ pr.title }}</a>
                     <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
                       <span class="font-semibold text-sky-300">{{ pr.repo }}</span>
                       <span>#{{ pr.number }}</span>
@@ -39,17 +39,17 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                     </div>
                     <div class="mt-3 flex flex-wrap gap-2 text-xs">
                       @if (pr.isDraft) {
-                        <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">Draft</span>
+                        <span class="cc-label-pill">Draft</span>
                       }
                       @if (pr.reviewDecision === 'APPROVED') {
-                        <span class="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 font-medium text-emerald-200">Approved</span>
+                        <span class="cc-label-pill border-emerald-400/25 bg-emerald-500/10 text-emerald-100">Approved</span>
                       }
                       @if (pr.reviewDecision === 'CHANGES_REQUESTED') {
-                        <span class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-1 font-medium text-rose-200">Changes requested</span>
+                        <span class="cc-label-pill border-rose-400/25 bg-rose-500/10 text-rose-100">Changes requested</span>
                       }
                     </div>
                   </div>
-                  <button type="button" (click)="togglePinned(pr)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                  <button type="button" (click)="togglePinned(pr)" class="cc-small-button cc-small-button-accent">Unpin</button>
                 </div>
               </article>
             }
@@ -59,10 +59,10 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           }
 
           @for (pr of unpinnedItems(); track pr.repoFull + '#' + pr.number) {
-            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+            <article class="cc-list-card p-5">
               <div class="flex items-start justify-between gap-4">
                 <div class="min-w-0">
-                  <a [href]="pr.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-amber-300">{{ pr.title }}</a>
+                  <a [href]="pr.url" target="_blank" class="text-base font-semibold leading-6 text-[var(--cc-text)] transition hover:text-indigo-300">{{ pr.title }}</a>
                   <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
                     <span class="font-semibold text-sky-300">{{ pr.repo }}</span>
                     <span>#{{ pr.number }}</span>
@@ -71,17 +71,17 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                   </div>
                   <div class="mt-3 flex flex-wrap gap-2 text-xs">
                     @if (pr.isDraft) {
-                      <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">Draft</span>
+                      <span class="cc-label-pill">Draft</span>
                     }
                     @if (pr.reviewDecision === 'APPROVED') {
-                      <span class="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 font-medium text-emerald-200">Approved</span>
+                      <span class="cc-label-pill border-emerald-400/25 bg-emerald-500/10 text-emerald-100">Approved</span>
                     }
                     @if (pr.reviewDecision === 'CHANGES_REQUESTED') {
-                      <span class="rounded-full border border-rose-400/30 bg-rose-400/10 px-3 py-1 font-medium text-rose-200">Changes requested</span>
+                      <span class="cc-label-pill border-rose-400/25 bg-rose-500/10 text-rose-100">Changes requested</span>
                     }
                   </div>
                 </div>
-                <button type="button" (click)="togglePinned(pr)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+                <button type="button" (click)="togglePinned(pr)" class="cc-small-button">Pin</button>
               </div>
             </article>
           }

--- a/frontend/src/app/features/repos/repos.page.ts
+++ b/frontend/src/app/features/repos/repos.page.ts
@@ -44,9 +44,9 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                   <button type="button" (click)="togglePinned(repo)" class="cc-small-button cc-small-button-accent">Unpin</button>
                 </div>
                 <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                  <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
-                  <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
-                  <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
+                  <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
+                  <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
+                  <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
                 </div>
                 <div class="mt-4 flex flex-wrap gap-3">
                   <button type="button" (click)="openIssueFilter(repo)" class="cc-small-button">View in issues</button>
@@ -79,9 +79,9 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                 <button type="button" (click)="togglePinned(repo)" class="cc-small-button">Pin</button>
               </div>
               <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
-                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
-                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
+                <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
+                <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
+                <div class="cc-stat-tile"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
               </div>
               <div class="mt-4 flex flex-wrap gap-3">
                 <button type="button" (click)="openIssueFilter(repo)" class="cc-small-button">View in issues</button>

--- a/frontend/src/app/features/repos/repos.page.ts
+++ b/frontend/src/app/features/repos/repos.page.ts
@@ -13,8 +13,8 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Repositories" title="Repositories" subtitle="Repository health, open issue counts, and quick handoff into issue views." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="repos.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
-        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search repos…" />
+        <button type="button" (click)="repos.refresh()" class="cc-action-button">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search repos…" />
       </div>
 
       @if (repos.isLoading()) {
@@ -28,7 +28,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           @if (pinnedItems().length) {
             <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
             @for (repo of pinnedItems(); track repo.repoFull) {
-              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <article class="cc-list-card p-5">
                 <div class="flex items-start justify-between gap-4">
                   <div>
                     <div class="text-base font-semibold text-[var(--cc-text)]">{{ repo.repo }}</div>
@@ -41,16 +41,16 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                       }
                     </div>
                   </div>
-                  <button type="button" (click)="togglePinned(repo)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                  <button type="button" (click)="togglePinned(repo)" class="cc-small-button cc-small-button-accent">Unpin</button>
                 </div>
                 <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                  <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
-                  <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
-                  <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
+                  <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
+                  <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
+                  <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
                 </div>
                 <div class="mt-4 flex flex-wrap gap-3">
-                  <button type="button" (click)="openIssueFilter(repo)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-muted)]">View in issues</button>
-                  <a [href]="'https://github.com/' + repo.repoFull + '/issues'" target="_blank" class="inline-flex rounded-full border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-amber-200">GitHub ↗</a>
+                  <button type="button" (click)="openIssueFilter(repo)" class="cc-small-button">View in issues</button>
+                  <a [href]="'https://github.com/' + repo.repoFull + '/issues'" target="_blank" class="cc-small-button cc-small-button-accent">GitHub ↗</a>
                 </div>
               </article>
             }
@@ -60,7 +60,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           }
 
           @for (repo of unpinnedItems(); track repo.repoFull) {
-            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+            <article class="cc-list-card p-5">
               <div class="flex items-start justify-between gap-4">
                 <div>
                   <div class="text-base font-semibold text-[var(--cc-text)]">{{ repo.repo }}</div>
@@ -76,16 +76,16 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                     }
                   </div>
                 </div>
-                <button type="button" (click)="togglePinned(repo)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+                <button type="button" (click)="togglePinned(repo)" class="cc-small-button">Pin</button>
               </div>
               <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
-                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
-                <div class="rounded-2xl bg-[var(--cc-surface-muted)] p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
+                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Open</div><div class="mt-1 font-semibold text-[var(--cc-text)]">{{ repo.openIssues }}</div></div>
+                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Bugs</div><div class="mt-1 font-semibold text-rose-300">{{ repo.bugs }}</div></div>
+                <div class="rounded-2xl bg-white/5 p-3"><div class="text-[var(--cc-text-soft)]">Features</div><div class="mt-1 font-semibold text-sky-300">{{ repo.enhancements }}</div></div>
               </div>
               <div class="mt-4 flex flex-wrap gap-3">
-                <button type="button" (click)="openIssueFilter(repo)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-muted)]">View in issues</button>
-                <a [href]="'https://github.com/' + repo.repoFull + '/issues'" target="_blank" class="inline-flex rounded-full border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-amber-200">GitHub ↗</a>
+                <button type="button" (click)="openIssueFilter(repo)" class="cc-small-button">View in issues</button>
+                <a [href]="'https://github.com/' + repo.repoFull + '/issues'" target="_blank" class="cc-small-button cc-small-button-accent">GitHub ↗</a>
               </div>
             </article>
           }

--- a/frontend/src/app/features/tasks/done.page.ts
+++ b/frontend/src/app/features/tasks/done.page.ts
@@ -10,8 +10,8 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Tasks" title="Completed Tasks" subtitle="Recently completed tasks from Obsidian." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="tasks.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
-        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search completed tasks…" />
+        <button type="button" (click)="tasks.refresh()" class="cc-action-button">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search completed tasks…" />
       </div>
 
       @if (tasks.isLoading()) {
@@ -23,10 +23,10 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
       } @else {
         <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
           @for (task of filteredItems(); track taskKey(task)) {
-            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+            <article class="cc-list-card p-5">
               <div class="text-base font-semibold leading-6 text-[var(--cc-text)]">{{ task.title }}</div>
               <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
-                <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">{{ task.source }}</span>
+                <span class="cc-label-pill">{{ task.source }}</span>
                 @if (task.section) {
                   <span>{{ task.section }}</span>
                 }

--- a/frontend/src/app/features/tasks/tasks.page.ts
+++ b/frontend/src/app/features/tasks/tasks.page.ts
@@ -12,8 +12,8 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
   template: `
     <app-view-shell eyebrow="Tasks" title="Tasks" subtitle="Open tasks from your Obsidian task lists, with search and pinning." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="tasks.refresh()" class="inline-flex items-center rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]">Refresh</button>
-        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="min-w-64 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm text-[var(--cc-text)] outline-none transition focus:border-amber-300/40" placeholder="Search tasks…" />
+        <button type="button" (click)="tasks.refresh()" class="cc-action-button">Refresh</button>
+        <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search tasks…" />
       </div>
 
       @if (tasks.isLoading()) {
@@ -27,12 +27,12 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           @if (pinnedItems().length) {
             <div class="lg:col-span-2 2xl:col-span-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-300"><span>📌</span><span>Pinned</span></div>
             @for (task of pinnedItems(); track taskKey(task)) {
-              <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+              <article class="cc-list-card p-5">
                 <div class="flex items-start justify-between gap-4">
                   <div class="min-w-0">
                     <div class="text-base font-semibold leading-6 text-[var(--cc-text)]">{{ task.title }}</div>
                     <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
-                      <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">{{ task.source }}</span>
+                      <span class="cc-label-pill">{{ task.source }}</span>
                       @if (task.section) {
                         <span>{{ task.section }}</span>
                       }
@@ -44,7 +44,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                       }
                     </div>
                   </div>
-                  <button type="button" (click)="togglePinned(task)" class="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs font-semibold text-amber-200">Unpin</button>
+                  <button type="button" (click)="togglePinned(task)" class="cc-small-button cc-small-button-accent">Unpin</button>
                 </div>
               </article>
             }
@@ -54,12 +54,12 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           }
 
           @for (task of unpinnedItems(); track taskKey(task)) {
-            <article class="rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-5 shadow-sm">
+            <article class="cc-list-card p-5">
               <div class="flex items-start justify-between gap-4">
                 <div class="min-w-0">
                   <div class="text-base font-semibold leading-6 text-[var(--cc-text)]">{{ task.title }}</div>
                   <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--cc-text-soft)]">
-                    <span class="rounded-full bg-[var(--cc-surface-muted)] px-3 py-1 font-medium text-[var(--cc-text-muted)]">{{ task.source }}</span>
+                    <span class="cc-label-pill">{{ task.source }}</span>
                     @if (task.section) {
                       <span>{{ task.section }}</span>
                     }
@@ -71,7 +71,7 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
                     }
                   </div>
                 </div>
-                <button type="button" (click)="togglePinned(task)" class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-3 py-2 text-xs font-semibold text-[var(--cc-text-muted)]">Pin</button>
+                <button type="button" (click)="togglePinned(task)" class="cc-small-button">Pin</button>
               </div>
             </article>
           }

--- a/frontend/src/app/layout/app-shell.component.ts
+++ b/frontend/src/app/layout/app-shell.component.ts
@@ -9,40 +9,45 @@ import { ThemeToggleComponent } from './theme-toggle.component';
   imports: [RouterLink, RouterLinkActive, RouterOutlet, ThemeToggleComponent],
   template: `
     <div class="min-h-screen cc-app-bg text-[var(--cc-text)]">
-      <header class="border-b border-[var(--cc-border)] bg-[var(--cc-header)]/95 backdrop-blur">
-        <div class="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-6 lg:px-8">
-          <div class="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-[var(--cc-text-soft)]">command.center</p>
-              <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">Command Center</h1>
-              <p class="mt-3 max-w-3xl text-sm leading-7 text-[var(--cc-text-muted)]">
-                GitHub, notes, tasks, calendar, analytics, and runtime status in one place.
-              </p>
+      <div class="mx-auto min-h-screen max-w-[1680px] xl:grid xl:grid-cols-[280px_minmax(0,1fr)] xl:gap-6 xl:px-6 xl:py-6">
+        <aside class="cc-shell-sidebar border-b border-[var(--cc-border)] px-4 py-4 sm:px-6 xl:sticky xl:top-6 xl:h-[calc(100vh-3rem)] xl:rounded-[28px] xl:border xl:px-5 xl:py-5">
+          <div class="flex items-center gap-4">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 via-sky-500 to-cyan-400 text-lg font-black text-white shadow-lg shadow-indigo-500/20">
+              C
             </div>
-
-            <div class="flex flex-wrap items-center gap-3">
-              <app-theme-toggle></app-theme-toggle>
+            <div class="min-w-0">
+              <div class="truncate text-xs font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">command.center</div>
+              <div class="mt-1 truncate text-lg font-semibold tracking-tight text-[var(--cc-text)]">Operations cockpit</div>
             </div>
           </div>
 
-          <nav class="flex flex-wrap gap-3">
+          <div class="mt-6 rounded-2xl border border-[var(--cc-border)] bg-white/5 px-4 py-4 text-sm text-[var(--cc-text-muted)]">
+            GitHub, notes, tasks, calendar, analytics, and runtime status in one place.
+          </div>
+
+          <nav class="mt-6 flex flex-wrap gap-2 xl:flex-col">
             @for (item of navItems(); track item.path) {
               <a
                 [routerLink]="item.path"
-                routerLinkActive="border-amber-300/40 bg-amber-300/15 text-[var(--cc-text)]"
+                routerLinkActive="cc-shell-nav-link-active"
                 [routerLinkActiveOptions]="{ exact: item.path === '/' }"
-                class="rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-white/15 hover:text-[var(--cc-text)]"
+                class="cc-shell-nav-link"
               >
-                {{ item.label }}
+                <span class="h-2.5 w-2.5 rounded-full bg-current opacity-55"></span>
+                <span>{{ item.label }}</span>
               </a>
             }
           </nav>
-        </div>
-      </header>
 
-      <main class="mx-auto max-w-7xl px-6 py-8 lg:px-8 lg:py-10">
-        <router-outlet></router-outlet>
-      </main>
+          <div class="mt-6 xl:mt-auto">
+            <app-theme-toggle></app-theme-toggle>
+          </div>
+        </aside>
+
+        <main class="min-w-0 px-4 py-5 sm:px-6 lg:px-8 xl:px-0 xl:py-0">
+          <router-outlet></router-outlet>
+        </main>
+      </div>
     </div>
   `,
 })

--- a/frontend/src/app/layout/theme-toggle.component.ts
+++ b/frontend/src/app/layout/theme-toggle.component.ts
@@ -5,13 +5,11 @@ import { ThemeService } from '../core/theme/theme.service';
 @Component({
   selector: 'app-theme-toggle',
   template: `
-    <button
-      type="button"
-      (click)="theme.toggleTheme()"
-      class="inline-flex items-center gap-3 rounded-full border border-[var(--cc-border)] bg-[var(--cc-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--cc-text-muted)] transition hover:border-amber-300/40 hover:text-[var(--cc-text)]"
-    >
-      <span class="text-base">{{ icon() }}</span>
-      <span>{{ label() }}</span>
+    <button type="button" (click)="theme.toggleTheme()" class="cc-action-button w-full justify-center xl:justify-between">
+      <span class="inline-flex items-center gap-3">
+        <span class="text-base">{{ icon() }}</span>
+        <span>{{ label() }}</span>
+      </span>
     </button>
   `,
 })

--- a/frontend/src/app/layout/view-shell.component.ts
+++ b/frontend/src/app/layout/view-shell.component.ts
@@ -4,22 +4,28 @@ import { Component, input } from '@angular/core';
   selector: 'app-view-shell',
   template: `
     <section class="space-y-6">
-      <header class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          @if (eyebrow()) {
-            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">{{ eyebrow() }}</p>
-          }
-          <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-4xl">{{ title() }}</h1>
-          @if (subtitle()) {
-            <p class="mt-3 max-w-3xl text-sm leading-7 text-[var(--cc-text-muted)]">{{ subtitle() }}</p>
-          }
-          @if (meta()) {
-            <p class="mt-3 text-xs font-medium uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">{{ meta() }}</p>
-          }
+      <header class="cc-panel rounded-[28px] px-6 py-6 md:px-8 md:py-7">
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            @if (eyebrow()) {
+              <p class="text-[11px] font-semibold uppercase tracking-[0.32em] text-[var(--cc-text-soft)]">{{ eyebrow() }}</p>
+            }
+            <h1 class="mt-3 text-3xl font-semibold tracking-tight text-[var(--cc-text)] sm:text-[2.5rem]">{{ title() }}</h1>
+            @if (subtitle()) {
+              <p class="mt-3 max-w-3xl text-sm leading-7 text-[var(--cc-text-muted)]">{{ subtitle() }}</p>
+            }
+          </div>
+
+          <div class="flex flex-wrap items-center gap-3">
+            <ng-content select="[view-actions]"></ng-content>
+          </div>
         </div>
-        <div class="flex flex-wrap items-center gap-3">
-          <ng-content select="[view-actions]"></ng-content>
-        </div>
+
+        @if (meta()) {
+          <div class="mt-5 inline-flex rounded-full border border-[var(--cc-border)] bg-white/5 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--cc-text-soft)]">
+            {{ meta() }}
+          </div>
+        }
       </header>
 
       <div class="space-y-6">

--- a/frontend/src/app/shared/ui/card.component.ts
+++ b/frontend/src/app/shared/ui/card.component.ts
@@ -7,13 +7,13 @@ import { Component, computed, input } from '@angular/core';
       @if (eyebrow() || title() || description()) {
         <header>
           @if (eyebrow()) {
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-[var(--cc-text-soft)]">{{ eyebrow() }}</p>
+            <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">{{ eyebrow() }}</p>
           }
           @if (title()) {
-            <h2 class="mt-3 text-2xl font-semibold tracking-tight text-[var(--cc-text)]">{{ title() }}</h2>
+            <h2 class="mt-3 text-[1.6rem] font-semibold tracking-tight text-[var(--cc-text)]">{{ title() }}</h2>
           }
           @if (description()) {
-            <p class="mt-3 text-sm leading-7 text-[var(--cc-text-muted)]">{{ description() }}</p>
+            <p class="mt-3 max-w-3xl text-sm leading-7 text-[var(--cc-text-muted)]">{{ description() }}</p>
           }
         </header>
       }
@@ -32,7 +32,7 @@ export class CardComponent {
   readonly compact = input(false);
 
   protected readonly classes = computed(() => {
-    const base = 'rounded-3xl border p-6 md:p-7';
+    const base = 'rounded-[28px] p-6 md:p-7';
     const tones = {
       default: 'cc-panel',
       muted: 'cc-panel-muted',

--- a/frontend/src/app/shared/ui/pill.component.ts
+++ b/frontend/src/app/shared/ui/pill.component.ts
@@ -12,14 +12,14 @@ export class PillComponent {
   readonly tone = input<'neutral' | 'accent' | 'success' | 'warning' | 'danger' | 'info'>('neutral');
 
   protected readonly classes = computed(() => {
-    const base = 'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em]';
+    const base = 'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em]';
     const tones = {
-      neutral: 'border-[var(--cc-border)] bg-[var(--cc-surface-muted)] text-[var(--cc-text-soft)]',
-      accent: 'border-amber-400/30 bg-amber-400/10 text-amber-200',
-      success: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200',
-      warning: 'border-amber-400/30 bg-amber-400/10 text-amber-200',
-      danger: 'border-rose-400/30 bg-rose-400/10 text-rose-200',
-      info: 'border-sky-400/30 bg-sky-400/10 text-sky-200',
+      neutral: 'border-[var(--cc-border)] bg-white/5 text-[var(--cc-text-soft)]',
+      accent: 'border-indigo-400/25 bg-indigo-500/10 text-indigo-100',
+      success: 'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
+      warning: 'border-amber-400/25 bg-amber-500/10 text-amber-100',
+      danger: 'border-rose-400/25 bg-rose-500/10 text-rose-100',
+      info: 'border-sky-400/25 bg-sky-500/10 text-sky-100',
     } as const;
 
     return `${base} ${tones[this.tone()]}`;

--- a/frontend/src/app/shared/ui/stat-card.component.ts
+++ b/frontend/src/app/shared/ui/stat-card.component.ts
@@ -4,7 +4,7 @@ import { Component, computed, input } from '@angular/core';
   selector: 'cc-stat-card',
   template: `
     <article [class]="classes()">
-      <p class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">{{ label() }}</p>
+      <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--cc-text-soft)]">{{ label() }}</p>
       <p class="mt-3 text-4xl font-semibold tracking-tight text-[var(--cc-text)]">{{ value() }}</p>
       @if (hint()) {
         <p class="mt-3 text-sm leading-6 text-[var(--cc-text-muted)]">{{ hint() }}</p>
@@ -19,12 +19,12 @@ export class StatCardComponent {
   readonly tone = input<'default' | 'accent' | 'success' | 'warning'>('default');
 
   protected readonly classes = computed(() => {
-    const base = 'rounded-2xl border p-5';
+    const base = 'rounded-[24px] p-5';
     const tones = {
       default: 'cc-panel-muted',
-      accent: 'border-sky-400/20 bg-sky-400/10',
-      success: 'border-emerald-400/20 bg-emerald-400/10',
-      warning: 'border-amber-400/20 bg-amber-400/10',
+      accent: 'border border-indigo-400/20 bg-indigo-500/10 shadow-[0_18px_40px_rgba(79,70,229,0.14)]',
+      success: 'border border-emerald-400/20 bg-emerald-500/10 shadow-[0_18px_40px_rgba(5,150,105,0.14)]',
+      warning: 'border border-amber-400/20 bg-amber-500/10 shadow-[0_18px_40px_rgba(217,119,6,0.14)]',
     } as const;
 
     return `${base} ${tones[this.tone()]}`;

--- a/frontend/src/app/shared/ui/state-panel.component.ts
+++ b/frontend/src/app/shared/ui/state-panel.component.ts
@@ -5,7 +5,9 @@ import { Component, computed, input } from '@angular/core';
   template: `
     <section [class]="classes()">
       <div class="flex items-start gap-4">
-        <div class="mt-0.5 text-lg">{{ icon() }}</div>
+        <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-white/10 text-base text-[var(--cc-text)]" [class]="iconWrapClasses()">
+          {{ icon() }}
+        </div>
         <div>
           <p class="text-sm font-semibold text-[var(--cc-text)]">{{ title() }}</p>
           <p class="mt-2 text-sm leading-6 text-[var(--cc-text-muted)]">{{ message() }}</p>
@@ -30,13 +32,23 @@ export class StatePanelComponent {
   });
 
   protected readonly classes = computed(() => {
-    const base = 'rounded-2xl border p-5';
+    const base = 'rounded-[24px] p-5';
     const tones = {
-      loading: 'border-[var(--cc-border)] bg-[var(--cc-surface-muted)]',
-      empty: 'border-[var(--cc-border)] bg-[var(--cc-surface-muted)]',
-      unavailable: 'border-rose-400/20 bg-rose-400/10',
+      loading: 'cc-panel-muted',
+      empty: 'cc-panel-soft',
+      unavailable: 'border border-rose-400/20 bg-rose-400/10 shadow-[0_18px_40px_rgba(159,18,57,0.18)]',
     } as const;
 
     return `${base} ${tones[this.kind()]}`;
+  });
+
+  protected readonly iconWrapClasses = computed(() => {
+    const tones = {
+      loading: 'bg-white/5',
+      empty: 'bg-white/5',
+      unavailable: 'bg-rose-500/15 text-rose-100',
+    } as const;
+
+    return tones[this.kind()];
   });
 }

--- a/frontend/src/app/shared/ui/status-badge.component.ts
+++ b/frontend/src/app/shared/ui/status-badge.component.ts
@@ -12,13 +12,13 @@ export class StatusBadgeComponent {
   readonly tone = input<'neutral' | 'success' | 'warning' | 'danger' | 'info'>('neutral');
 
   protected readonly classes = computed(() => {
-    const base = 'inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]';
+    const base = 'inline-flex items-center rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em]';
     const tones = {
-      neutral: 'border-[var(--cc-border)] bg-[var(--cc-surface-muted)] text-[var(--cc-text-soft)]',
-      success: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200',
-      warning: 'border-amber-400/30 bg-amber-400/10 text-amber-200',
-      danger: 'border-rose-400/30 bg-rose-400/10 text-rose-200',
-      info: 'border-sky-400/30 bg-sky-400/10 text-sky-200',
+      neutral: 'border-[var(--cc-border)] bg-white/5 text-[var(--cc-text-soft)]',
+      success: 'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
+      warning: 'border-amber-400/25 bg-amber-500/10 text-amber-100',
+      danger: 'border-rose-400/25 bg-rose-500/10 text-rose-100',
+      info: 'border-sky-400/25 bg-sky-500/10 text-sky-100',
     } as const;
 
     return `${base} ${tones[this.tone()]}`;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -4,33 +4,41 @@
   color-scheme: dark;
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 
-  --cc-bg: #07101f;
-  --cc-bg-secondary: #0d172a;
-  --cc-header: rgba(8, 15, 30, 0.92);
-  --cc-surface: rgba(15, 23, 42, 0.92);
-  --cc-surface-muted: rgba(15, 23, 42, 0.72);
-  --cc-surface-highlight: linear-gradient(135deg, rgba(56, 189, 248, 0.14), rgba(245, 158, 11, 0.12));
-  --cc-border: rgba(148, 163, 184, 0.18);
-  --cc-border-strong: rgba(248, 250, 252, 0.14);
-  --cc-text: #e2e8f0;
-  --cc-text-muted: #cbd5e1;
-  --cc-text-soft: #94a3b8;
+  --cc-bg: #0f172a;
+  --cc-bg-secondary: #111827;
+  --cc-header: rgba(15, 23, 42, 0.82);
+  --cc-sidebar: rgba(15, 23, 42, 0.76);
+  --cc-surface: rgba(15, 23, 42, 0.84);
+  --cc-surface-muted: rgba(30, 41, 59, 0.72);
+  --cc-surface-soft: rgba(15, 23, 42, 0.58);
+  --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(56, 189, 248, 0.14));
+  --cc-border: rgba(148, 163, 184, 0.16);
+  --cc-border-strong: rgba(255, 255, 255, 0.16);
+  --cc-text: #e5edf8;
+  --cc-text-muted: #c7d2e4;
+  --cc-text-soft: #93a4bd;
+  --cc-shadow-lg: 0 24px 60px rgba(2, 6, 23, 0.28);
+  --cc-shadow-md: 0 18px 40px rgba(15, 23, 42, 0.18);
 }
 
 html.light {
   color-scheme: light;
 
-  --cc-bg: #f7fafc;
-  --cc-bg-secondary: rgba(255, 255, 255, 0.88);
-  --cc-header: rgba(255, 255, 255, 0.92);
-  --cc-surface: rgba(255, 255, 255, 0.95);
-  --cc-surface-muted: rgba(241, 245, 249, 0.92);
-  --cc-surface-highlight: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(245, 158, 11, 0.08));
-  --cc-border: rgba(15, 23, 42, 0.1);
-  --cc-border-strong: rgba(15, 23, 42, 0.14);
+  --cc-bg: #f1f5f9;
+  --cc-bg-secondary: #e2e8f0;
+  --cc-header: rgba(255, 255, 255, 0.82);
+  --cc-sidebar: rgba(255, 255, 255, 0.84);
+  --cc-surface: rgba(255, 255, 255, 0.88);
+  --cc-surface-muted: rgba(248, 250, 252, 0.92);
+  --cc-surface-soft: rgba(255, 255, 255, 0.66);
+  --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(56, 189, 248, 0.09));
+  --cc-border: rgba(15, 23, 42, 0.08);
+  --cc-border-strong: rgba(15, 23, 42, 0.12);
   --cc-text: #0f172a;
   --cc-text-muted: #334155;
   --cc-text-soft: #64748b;
+  --cc-shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.1);
+  --cc-shadow-md: 0 18px 40px rgba(15, 23, 42, 0.08);
 }
 
 html,
@@ -41,8 +49,10 @@ body {
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top left, rgba(245, 158, 11, 0.16), transparent 24%),
+    radial-gradient(circle at top left, rgba(99, 102, 241, 0.24), transparent 24%),
     radial-gradient(circle at top right, rgba(56, 189, 248, 0.18), transparent 28%),
+    radial-gradient(circle at bottom left, rgba(14, 165, 233, 0.12), transparent 24%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 18%),
     var(--cc-bg);
   color: var(--cc-text);
   transition: background 200ms ease, color 200ms ease;
@@ -69,7 +79,7 @@ code {
 }
 
 ::selection {
-  background: rgba(245, 158, 11, 0.22);
+  background: rgba(99, 102, 241, 0.24);
 }
 
 .cc-app-bg {
@@ -80,17 +90,95 @@ code {
 
 .cc-panel {
   background: var(--cc-surface);
-  border-color: var(--cc-border);
-  box-shadow: 0 26px 80px rgba(2, 6, 23, 0.16);
+  border: 1px solid var(--cc-border);
+  box-shadow: var(--cc-shadow-lg);
+  backdrop-filter: blur(18px);
 }
 
 .cc-panel-muted {
   background: var(--cc-surface-muted);
-  border-color: var(--cc-border);
+  border: 1px solid var(--cc-border);
+  box-shadow: var(--cc-shadow-md);
+  backdrop-filter: blur(18px);
+}
+
+.cc-panel-soft {
+  background: var(--cc-surface-soft);
+  border: 1px solid var(--cc-border);
+  backdrop-filter: blur(18px);
 }
 
 .cc-panel-highlight {
   background: var(--cc-surface-highlight), var(--cc-surface);
-  border-color: var(--cc-border-strong);
-  box-shadow: 0 26px 80px rgba(2, 6, 23, 0.16);
+  border: 1px solid var(--cc-border-strong);
+  box-shadow: var(--cc-shadow-lg);
+  backdrop-filter: blur(18px);
+}
+
+.cc-shell-sidebar {
+  background: var(--cc-sidebar);
+  border: 1px solid var(--cc-border);
+  box-shadow: var(--cc-shadow-lg);
+  backdrop-filter: blur(20px);
+}
+
+.cc-shell-nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--cc-text-muted);
+  transition: all 180ms ease;
+}
+
+.cc-shell-nav-link:hover {
+  border-color: var(--cc-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--cc-text);
+}
+
+.cc-shell-nav-link-active {
+  border-color: rgba(99, 102, 241, 0.2);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(56, 189, 248, 0.12));
+  color: var(--cc-text);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.cc-action-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.625rem;
+  border-radius: 9999px;
+  border: 1px solid var(--cc-border);
+  background: var(--cc-surface-muted);
+  padding: 0.7rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--cc-text-muted);
+  transition: all 180ms ease;
+}
+
+.cc-action-button:hover {
+  border-color: rgba(99, 102, 241, 0.28);
+  color: var(--cc-text);
+  transform: translateY(-1px);
+}
+
+.cc-input {
+  border-radius: 9999px;
+  border: 1px solid var(--cc-border);
+  background: var(--cc-surface-muted);
+  color: var(--cc-text);
+  outline: none;
+  transition: all 180ms ease;
+}
+
+.cc-input:focus {
+  border-color: rgba(99, 102, 241, 0.28);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.08);
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -182,3 +182,75 @@ code {
   border-color: rgba(99, 102, 241, 0.28);
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.08);
 }
+
+.cc-card-button {
+  border-radius: 1.5rem;
+  border: 1px solid var(--cc-border);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: var(--cc-shadow-md);
+  backdrop-filter: blur(16px);
+  transition: all 180ms ease;
+}
+
+.cc-card-button:hover {
+  transform: translateY(-2px);
+  border-color: rgba(99, 102, 241, 0.24);
+}
+
+.cc-list-card {
+  border-radius: 1.5rem;
+  border: 1px solid var(--cc-border);
+  background: var(--cc-surface-soft);
+  box-shadow: var(--cc-shadow-md);
+  backdrop-filter: blur(16px);
+  transition: all 180ms ease;
+}
+
+.cc-list-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(99, 102, 241, 0.24);
+}
+
+.cc-small-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid var(--cc-border);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.55rem 0.85rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--cc-text-muted);
+  transition: all 180ms ease;
+}
+
+.cc-small-button:hover {
+  border-color: rgba(99, 102, 241, 0.24);
+  color: var(--cc-text);
+}
+
+.cc-small-button-accent {
+  border-color: rgba(99, 102, 241, 0.24);
+  background: rgba(99, 102, 241, 0.14);
+  color: #dbeafe;
+}
+
+.cc-small-button-danger {
+  border-color: rgba(251, 113, 133, 0.28);
+  background: rgba(244, 63, 94, 0.12);
+  color: #ffe4e6;
+}
+
+.cc-label-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid var(--cc-border);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--cc-text-muted);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -254,3 +254,19 @@ code {
   font-weight: 600;
   color: var(--cc-text-muted);
 }
+
+.cc-stat-tile {
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.75rem;
+}
+
+.cc-table-shell {
+  overflow: hidden;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 30px 90px -48px rgba(15, 23, 42, 1);
+  backdrop-filter: blur(24px);
+}


### PR DESCRIPTION
## Summary
- refresh the Angular shell, surfaces, and shared UI primitives toward the TailAdmin-inspired direction for #65
- polish the highest-traffic views first, then carry the new visual language across the remaining dashboard pages
- add shared style utilities for action buttons, list cards, small controls, stat tiles, and analytics table surfaces

## Testing
- npm test

Closes #65.
