### PR TITLE
Add home panel quick actions

### DIFF
--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -7,7 +7,9 @@ import { PinService } from '../../core/state/pin.service';
 import { ReminderItem, RemindersService } from '../../core/state/reminders.service';
 import { CalendarEvent, IssueItem, PullRequestItem, RepoSummary, TaskItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { PanelAction } from '../../shared/models/panel-action';
 import { CardComponent } from '../../shared/ui/card.component';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
@@ -22,7 +24,7 @@ interface PinnedHomeItem {
 
 @Component({
   selector: 'app-home-page',
-  imports: [ViewShellComponent, CardComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, CardComponent, PanelActionsComponent, PillComponent, StatePanelComponent],
   template: `
     <app-view-shell
       eyebrow="Overview"
@@ -140,6 +142,9 @@ interface PinnedHomeItem {
                   <div class="text-lg font-semibold tracking-tight text-[var(--cc-text)]">{{ sectionLabel(sectionId) }}</div>
                 </div>
                 <div class="flex flex-wrap justify-end gap-2">
+                  @if (panelActions(sectionId).length) {
+                    <cc-panel-actions [actions]="panelActions(sectionId)" (actionSelected)="onPanelAction(sectionId, $event)"></cc-panel-actions>
+                  }
                   <button type="button" (click)="homeLayout.toggleCollapsed(sectionId)" class="cc-small-button">{{ isSectionCollapsed(sectionId) ? 'Expand' : 'Collapse' }}</button>
                   @if (homeLayout.customizeMode()) {
                     <button type="button" (click)="homeLayout.pinToTop(sectionId)" class="cc-small-button">Top</button>
@@ -331,6 +336,7 @@ export class HomePage {
   protected readonly editingReminderId = signal<string | null>(null);
   protected readonly reminderText = signal('');
   protected readonly reminderDue = signal<string | null>(null);
+  protected readonly copiedPanel = signal<string | null>(null);
 
   protected readonly onlineServices = computed(() => (this.infra.data() ?? []).filter((process) => process.status === 'online').length);
   protected readonly upcomingEvents = computed(() => {
@@ -439,6 +445,34 @@ export class HomePage {
     this.data.refreshAll();
   }
 
+  protected panelActions(sectionId: string): PanelAction[] {
+    const route = this.panelRoute(sectionId);
+    const copied = this.copiedPanel() === sectionId;
+
+    const actions: PanelAction[] = [];
+    if (route) actions.push({ id: 'open', label: 'Open', icon: '↗' });
+    if (this.canRefreshPanel(sectionId)) actions.push({ id: 'refresh', label: 'Refresh', icon: '↻', tone: 'accent' });
+    if (route) actions.push({ id: 'copy', label: copied ? 'Copied' : 'Copy link', icon: '⧉' });
+    return actions;
+  }
+
+  protected onPanelAction(sectionId: string, actionId: string): void {
+    if (actionId === 'open') {
+      const route = this.panelRoute(sectionId);
+      if (route) this.go(route);
+      return;
+    }
+
+    if (actionId === 'refresh') {
+      this.refreshPanel(sectionId);
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyPanelLink(sectionId);
+    }
+  }
+
   protected go(path: string): void {
     this.router.navigateByUrl(path);
   }
@@ -460,6 +494,39 @@ export class HomePage {
 
   protected isSectionHidden(sectionId: string): boolean {
     return this.homeLayout.layout().hidden.includes(sectionId) || (sectionId === 'pinned' && !this.homeLayout.customizeMode() && this.pinnedHomeItems().length === 0);
+  }
+
+  protected panelRoute(sectionId: string): string | null {
+    return {
+      upcoming: '/calendar',
+      issues: '/issues/urgent',
+      tasks: '/tasks',
+      'daily-note': '/notes',
+      standup: '/notes',
+      pinned: null,
+    }[sectionId] ?? null;
+  }
+
+  protected canRefreshPanel(sectionId: string): boolean {
+    return ['upcoming', 'issues', 'tasks', 'daily-note', 'standup'].includes(sectionId);
+  }
+
+  protected refreshPanel(sectionId: string): void {
+    if (sectionId === 'upcoming') this.calendar.refresh();
+    if (sectionId === 'issues') this.issues.refresh();
+    if (sectionId === 'tasks') this.tasks.refresh();
+    if (sectionId === 'daily-note') this.notes.refresh();
+    if (sectionId === 'standup') this.standup.refresh();
+  }
+
+  protected async copyPanelLink(sectionId: string): Promise<void> {
+    const route = this.panelRoute(sectionId);
+    if (!route || typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(`${window.location.origin}${route}`);
+    this.copiedPanel.set(sectionId);
+    window.setTimeout(() => {
+      if (this.copiedPanel() === sectionId) this.copiedPanel.set(null);
+    }, 1500);
   }
 
   protected openReminderComposer(): void {

--- a/frontend/src/app/shared/models/panel-action.ts
+++ b/frontend/src/app/shared/models/panel-action.ts
@@ -1,0 +1,7 @@
+export interface PanelAction {
+  id: string;
+  label: string;
+  icon?: string;
+  tone?: 'default' | 'accent';
+  disabled?: boolean;
+}

--- a/frontend/src/app/shared/ui/panel-actions.component.ts
+++ b/frontend/src/app/shared/ui/panel-actions.component.ts
@@ -1,0 +1,33 @@
+import { Component, input, output } from '@angular/core';
+
+import { PanelAction } from '../models/panel-action';
+
+@Component({
+  selector: 'cc-panel-actions',
+  template: `
+    <div class="cc-panel-actions">
+      @for (action of actions(); track action.id) {
+        <button
+          type="button"
+          [disabled]="action.disabled"
+          [class]="actionClass(action)"
+          (click)="actionSelected.emit(action.id)"
+        >
+          @if (action.icon) {
+            <span aria-hidden="true">{{ action.icon }}</span>
+          }
+          <span>{{ action.label }}</span>
+        </button>
+      }
+    </div>
+  `,
+})
+export class PanelActionsComponent {
+  readonly actions = input<PanelAction[]>([]);
+  readonly actionSelected = output<string>();
+
+  protected actionClass(action: PanelAction): string {
+    const tone = action.tone === 'accent' ? 'cc-panel-action cc-panel-action-accent' : 'cc-panel-action';
+    return action.disabled ? `${tone} opacity-60` : tone;
+  }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -309,3 +309,37 @@ code {
   background: rgba(255, 255, 255, 0.08);
   color: var(--cc-text-soft);
 }
+
+.cc-panel-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.cc-panel-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 9999px;
+  border: 1px solid var(--cc-border);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.45rem 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cc-text-soft);
+  transition: all 180ms ease;
+}
+
+.cc-panel-action:hover {
+  border-color: rgba(99, 102, 241, 0.24);
+  color: var(--cc-text);
+}
+
+.cc-panel-action-accent {
+  border-color: rgba(99, 102, 241, 0.24);
+  background: rgba(99, 102, 241, 0.14);
+  color: #dbeafe;
+}


### PR DESCRIPTION
## Summary
- add a reusable panel action strip for compact per-panel controls
- wire Home dashboard panels to support single-panel refresh, open-view shortcuts, and deep-link copying
- establish the shared action pattern that later work like #63 can build on

## Testing
- npm test

Part of #64.
