### PR TITLE
Extend panel quick actions across the main views

### DIFF
--- a/frontend/src/app/features/analytics/analytics.page.ts
+++ b/frontend/src/app/features/analytics/analytics.page.ts
@@ -2,15 +2,17 @@ import { Component, computed, inject } from '@angular/core';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-analytics-page',
-  imports: [ViewShellComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Analytics" title="Analytics" subtitle="Traffic summary and site-level metrics." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="analytics.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
       </div>
 
       @if (analytics.isLoading()) {
@@ -69,6 +71,7 @@ export class AnalyticsPage {
   private readonly data = inject(DashboardDataService);
 
   protected readonly analytics = this.data.analytics();
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
   protected readonly averageBounce = computed(() => {
     const totals = this.analytics.data()?.totals;
     if (!totals || totals.visits === 0) return 0;
@@ -79,6 +82,22 @@ export class AnalyticsPage {
     const summary = `Last 30 days · ${count} properties`;
     return this.analytics.source()?.status ? `${summary} · ${this.analytics.source()!.status}` : summary;
   });
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.analytics.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
+  }
 
   protected shareOfPageviews(pageviews: number): number {
     const total = this.analytics.data()?.totals.pageviews ?? 0;

--- a/frontend/src/app/features/calendar/calendar.page.ts
+++ b/frontend/src/app/features/calendar/calendar.page.ts
@@ -4,15 +4,17 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { CalendarEvent } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-calendar-page',
-  imports: [ViewShellComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Calendar" title="Calendar" subtitle="Upcoming events with quick pinning." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="calendar.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
       </div>
 
       @if (calendar.isLoading()) {
@@ -68,6 +70,7 @@ export class CalendarPage {
   protected readonly pins = inject(PinService);
 
   protected readonly calendar = this.data.calendar();
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
   protected readonly allItems = computed(() => this.calendar.data() ?? []);
   protected readonly pinnedItems = computed(() => this.allItems().filter((event) => this.pins.isPinned('event', this.eventKey(event))));
   protected readonly unpinnedItems = computed(() => this.allItems().filter((event) => !this.pins.isPinned('event', this.eventKey(event))));
@@ -75,6 +78,22 @@ export class CalendarPage {
 
   protected togglePinned(event: CalendarEvent): void {
     this.pins.toggle('event', this.eventKey(event));
+  }
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.calendar.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
   }
 
   protected eventKey(event: CalendarEvent): string {

--- a/frontend/src/app/features/infra/infra.page.ts
+++ b/frontend/src/app/features/infra/infra.page.ts
@@ -2,16 +2,18 @@ import { Component, computed, inject } from '@angular/core';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
 import { PillComponent } from '../../shared/ui/pill.component';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-infra-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PillComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Infrastructure" title="Infrastructure" subtitle="Process status, uptime, restarts, and degraded-state handling." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="infra.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
       </div>
 
       @if (infra.isLoading()) {
@@ -55,6 +57,7 @@ export class InfraPage {
   private readonly data = inject(DashboardDataService);
 
   protected readonly infra = this.data.infra();
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
   protected readonly onlineCount = computed(() => (this.infra.data() ?? []).filter((process) => process.status === 'online').length);
   protected readonly downCount = computed(() => (this.infra.data() ?? []).filter((process) => process.status !== 'online').length);
   protected readonly restartCount = computed(() => (this.infra.data() ?? []).reduce((sum, process) => sum + (process.restarts || 0), 0));
@@ -62,6 +65,22 @@ export class InfraPage {
     const summary = `${this.onlineCount()} online · ${this.downCount()} down · ${this.restartCount()} restarts`;
     return this.infra.source()?.status ? `${summary} · ${this.infra.source()!.status}` : summary;
   });
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.infra.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
+  }
 
   protected formatUptime(ms: number | null): string {
     if (!ms) return '—';

--- a/frontend/src/app/features/issues/issue-list.page.ts
+++ b/frontend/src/app/features/issues/issue-list.page.ts
@@ -5,6 +5,8 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { IssueItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 type IssueSection = {
@@ -16,11 +18,11 @@ type IssueSection = {
 
 @Component({
   selector: 'app-issue-list-page',
-  imports: [ViewShellComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell [eyebrow]="eyebrow()" [title]="title()" [subtitle]="subtitle()" [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="issues.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
         <input
           [value]="searchText()"
           (input)="searchText.set($any($event.target).value)"
@@ -179,6 +181,7 @@ export class IssueListPage {
   protected readonly issues = this.data.issues();
   protected readonly searchText = signal('');
   protected readonly repoFilter = signal<string | null>(this.route.snapshot.queryParamMap.get('repo'));
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
 
   protected readonly priority = this.route.snapshot.data['priority'] as 'urgent' | 'active' | 'backlog';
   protected readonly title = computed(() => this.route.snapshot.data['title'] as string);
@@ -239,6 +242,17 @@ export class IssueListPage {
     this.pins.toggle('issue', this.issueKey(issue));
   }
 
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.issues.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
   protected close(issue: IssueItem): void {
     if (!window.confirm(`Close issue #${issue.number}?`)) return;
     this.data.closeIssue(issue.repoFull, issue.number);
@@ -283,6 +297,11 @@ export class IssueListPage {
     if (issue.priority === 'urgent') return 'rgba(251, 113, 133, 0.8)';
     if (issue.priority === 'active') return 'rgba(56, 189, 248, 0.8)';
     return 'rgba(148, 163, 184, 0.5)';
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
   }
 
   protected timeAgo(iso: string): string {

--- a/frontend/src/app/features/notes/notes.page.ts
+++ b/frontend/src/app/features/notes/notes.page.ts
@@ -2,16 +2,18 @@ import { Component, computed, inject } from '@angular/core';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
 import { PillComponent } from '../../shared/ui/pill.component';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-notes-page',
-  imports: [ViewShellComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PillComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Notes" title="Notes" subtitle="Daily note, recent decisions, and latest standup context." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
       </div>
 
       <section class="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
@@ -109,6 +111,7 @@ export class NotesPage {
 
   protected readonly notes = this.data.notes();
   protected readonly standup = this.data.standup();
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
   protected readonly meta = computed(() => {
     const noteBits = this.notes.data()?.dailyNote ? this.notes.data()!.dailyNote!.date : 'No recent daily note';
     const decisions = this.notes.data()?.decisions.length ?? 0;
@@ -118,6 +121,22 @@ export class NotesPage {
   protected refresh(): void {
     this.notes.refresh();
     this.standup.refresh();
+  }
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
   }
 
   protected cleanedBullet(bullet: string): string {

--- a/frontend/src/app/features/prs/prs.page.ts
+++ b/frontend/src/app/features/prs/prs.page.ts
@@ -4,6 +4,8 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { PullRequestItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 type PrSection = {
@@ -15,11 +17,11 @@ type PrSection = {
 
 @Component({
   selector: 'app-prs-page',
-  imports: [ViewShellComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Review" title="Pull Requests" subtitle="Open pull requests with stronger action cues, ownership, and scanability." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="prs.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search PRs…" />
       </div>
 
@@ -129,6 +131,7 @@ export class PrsPage {
 
   protected readonly prs = this.data.prs();
   protected readonly searchText = signal('');
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
 
   protected readonly allItems = computed(() => this.prs.data() ?? []);
   protected readonly filteredItems = computed(() => {
@@ -160,6 +163,17 @@ export class PrsPage {
 
   protected togglePinned(pr: PullRequestItem): void {
     this.pins.toggle('pr', this.prKey(pr));
+  }
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.prs.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
   }
 
   protected canUseGitHubAvatar(login?: string | null): boolean {
@@ -212,6 +226,11 @@ export class PrsPage {
     if (pr.reviewDecision === 'APPROVED') return 'rgba(52, 211, 153, 0.8)';
     if (pr.isDraft) return 'rgba(148, 163, 184, 0.5)';
     return 'rgba(56, 189, 248, 0.8)';
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
   }
 
   protected timeAgo(iso: string): string {

--- a/frontend/src/app/features/repos/repos.page.ts
+++ b/frontend/src/app/features/repos/repos.page.ts
@@ -5,15 +5,17 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { RepoSummary } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-repos-page',
-  imports: [ViewShellComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Repositories" title="Repositories" subtitle="Repository health, open issue counts, and quick handoff into issue views." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="repos.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search repos…" />
       </div>
 
@@ -101,6 +103,7 @@ export class ReposPage {
 
   protected readonly repos = this.data.repos();
   protected readonly searchText = signal('');
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
   protected readonly allItems = computed(() => [...(this.repos.data() ?? [])].sort((a, b) => b.openIssues - a.openIssues));
   protected readonly filteredItems = computed(() => {
     const q = this.searchText().trim().toLowerCase();
@@ -119,8 +122,24 @@ export class ReposPage {
     this.pins.toggle('repo', repo.repoFull);
   }
 
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.repos.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
   protected openIssueFilter(repo: RepoSummary): void {
     this.router.navigate(['/issues/active'], { queryParams: { repo: repo.repo } });
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
   }
 
   protected timeAgo(iso: string): string {

--- a/frontend/src/app/features/tasks/done.page.ts
+++ b/frontend/src/app/features/tasks/done.page.ts
@@ -2,15 +2,17 @@ import { Component, computed, inject, signal } from '@angular/core';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-done-page',
-  imports: [ViewShellComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Tasks" title="Completed Tasks" subtitle="Recently completed tasks from Obsidian." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="tasks.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search completed tasks…" />
       </div>
 
@@ -47,6 +49,7 @@ export class DonePage {
 
   protected readonly tasks = this.data.tasks();
   protected readonly searchText = signal('');
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
   protected readonly allItems = computed(() => this.tasks.data()?.completed ?? []);
   protected readonly filteredItems = computed(() => {
     const q = this.searchText().trim().toLowerCase();
@@ -62,6 +65,22 @@ export class DonePage {
     const summary = `${this.filteredItems().length} completed task${this.filteredItems().length === 1 ? '' : 's'}`;
     return source?.status ? `${summary} · ${source.status}` : summary;
   });
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.tasks.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
+  }
 
   protected taskKey(task: { title: string }): string {
     return encodeURIComponent(task.title).substring(0, 80);

--- a/frontend/src/app/features/tasks/tasks.page.ts
+++ b/frontend/src/app/features/tasks/tasks.page.ts
@@ -4,15 +4,17 @@ import { DashboardDataService } from '../../core/data/dashboard-data.service';
 import { PinService } from '../../core/state/pin.service';
 import { TaskItem } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
 
 @Component({
   selector: 'app-tasks-page',
-  imports: [ViewShellComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
   template: `
     <app-view-shell eyebrow="Tasks" title="Tasks" subtitle="Open tasks from your Obsidian task lists, with search and pinning." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
-        <button type="button" (click)="tasks.refresh()" class="cc-action-button">Refresh</button>
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
         <input [value]="searchText()" (input)="searchText.set($any($event.target).value)" class="cc-input min-w-64 px-4 py-2 text-sm" placeholder="Search tasks…" />
       </div>
 
@@ -86,6 +88,7 @@ export class TasksPage {
 
   protected readonly tasks = this.data.tasks();
   protected readonly searchText = signal('');
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
   protected readonly allItems = computed(() => this.tasks.data()?.open ?? []);
   protected readonly filteredItems = computed(() => {
     const q = this.searchText().trim().toLowerCase();
@@ -108,6 +111,22 @@ export class TasksPage {
 
   protected togglePinned(task: TaskItem): void {
     this.pins.toggle('task', this.taskKey(task));
+  }
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.tasks.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
   }
 
   protected taskKey(task: TaskItem): string {

--- a/frontend/src/app/shared/models/panel-action.ts
+++ b/frontend/src/app/shared/models/panel-action.ts
@@ -5,3 +5,8 @@ export interface PanelAction {
   tone?: 'default' | 'accent';
   disabled?: boolean;
 }
+
+export const STANDARD_PANEL_ACTIONS: PanelAction[] = [
+  { id: 'refresh', label: 'Refresh', icon: '↻', tone: 'accent' },
+  { id: 'copy', label: 'Copy link', icon: '⧉' },
+];


### PR DESCRIPTION
## Summary
- extend the shared panel action strip into the main view headers across the dashboard
- standardize refresh and copy-link quick actions for issues, PRs, tasks, notes, calendar, repos, infra, and analytics
- continue the #64 action model so the rest of the dashboard matches the Home panel action pass from #85

## Testing
- npm test

Part of #64.
