### PR TITLE
Add the first command palette slice for command-center

### DIFF
--- a/frontend/src/app/layout/app-shell.component.ts
+++ b/frontend/src/app/layout/app-shell.component.ts
@@ -1,12 +1,13 @@
-import { Component, input } from '@angular/core';
+import { Component, HostListener, input, signal } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { NavItem } from '../shared/models/nav-item';
+import { CommandPaletteComponent } from '../shared/ui/command-palette.component';
 import { ThemeToggleComponent } from './theme-toggle.component';
 
 @Component({
   selector: 'app-shell',
-  imports: [RouterLink, RouterLinkActive, RouterOutlet, ThemeToggleComponent],
+  imports: [RouterLink, RouterLinkActive, RouterOutlet, CommandPaletteComponent, ThemeToggleComponent],
   template: `
     <div class="min-h-screen cc-app-bg text-[var(--cc-text)]">
       <div class="mx-auto min-h-screen max-w-[1680px] xl:grid xl:grid-cols-[280px_minmax(0,1fr)] xl:gap-6 xl:px-6 xl:py-6">
@@ -21,9 +22,11 @@ import { ThemeToggleComponent } from './theme-toggle.component';
             </div>
           </div>
 
-          <div class="mt-6 rounded-2xl border border-[var(--cc-border)] bg-white/5 px-4 py-4 text-sm text-[var(--cc-text-muted)]">
-            GitHub, notes, tasks, calendar, analytics, and runtime status in one place.
-          </div>
+          <button type="button" class="mt-6 w-full rounded-2xl border border-[var(--cc-border)] bg-white/5 px-4 py-4 text-left text-sm text-[var(--cc-text-muted)] transition hover:border-sky-400/40 hover:text-[var(--cc-text)]" (click)="openPalette()">
+            <div class="font-semibold text-[var(--cc-text)]">Open command palette</div>
+            <div class="mt-1">Jump to a view, repo, issue, PR, or quick action.</div>
+            <div class="mt-3 inline-flex items-center rounded-full border border-[var(--cc-border)] px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--cc-text-soft)]">Ctrl/Cmd + K</div>
+          </button>
 
           <nav class="mt-6 flex flex-wrap gap-2 xl:flex-col">
             @for (item of navItems(); track item.path) {
@@ -48,9 +51,34 @@ import { ThemeToggleComponent } from './theme-toggle.component';
           <router-outlet></router-outlet>
         </main>
       </div>
+
+      <cc-command-palette [open]="paletteOpen()" [navItems]="navItems()" (closed)="closePalette()"></cc-command-palette>
     </div>
   `,
 })
 export class AppShellComponent {
   readonly navItems = input.required<NavItem[]>();
+  protected readonly paletteOpen = signal(false);
+
+  @HostListener('document:keydown', ['$event'])
+  protected onDocumentKeydown(event: KeyboardEvent): void {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+      event.preventDefault();
+      this.paletteOpen.set(true);
+      return;
+    }
+
+    if (event.key === 'Escape' && this.paletteOpen()) {
+      event.preventDefault();
+      this.closePalette();
+    }
+  }
+
+  protected openPalette(): void {
+    this.paletteOpen.set(true);
+  }
+
+  protected closePalette(): void {
+    this.paletteOpen.set(false);
+  }
 }

--- a/frontend/src/app/shared/ui/command-palette.component.ts
+++ b/frontend/src/app/shared/ui/command-palette.component.ts
@@ -1,0 +1,264 @@
+import { Component, ElementRef, computed, effect, inject, input, output, signal, viewChild } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { ThemeService } from '../../core/theme/theme.service';
+import { IssueItem, PullRequestItem, RepoSummary } from '../../models/api';
+import { NavItem } from '../models/nav-item';
+
+interface CommandPaletteItem {
+  id: string;
+  group: 'Actions' | 'Views' | 'Repos' | 'Issues' | 'PRs';
+  title: string;
+  subtitle: string;
+  keywords: string;
+  run: () => void;
+}
+
+@Component({
+  selector: 'cc-command-palette',
+  standalone: true,
+  template: `
+    @if (open()) {
+      <div class="cc-command-palette-backdrop" (click)="close()">
+        <section class="cc-command-palette-shell" (click)="$event.stopPropagation()">
+          <div class="border-b border-[var(--cc-border)] px-4 py-4 sm:px-5">
+            <input
+              #paletteInput
+              [value]="query()"
+              (input)="onQueryChange($any($event.target).value)"
+              (keydown)="onInputKeydown($event)"
+              class="cc-command-palette-input"
+              placeholder="Jump to a view, repo, issue, PR, or action..."
+            />
+          </div>
+
+          @if (!flatResults().length) {
+            <div class="px-5 py-10 text-center text-sm text-[var(--cc-text-soft)]">
+              No commands match that search.
+            </div>
+          } @else {
+            <div class="max-h-[70vh] overflow-y-auto px-3 py-3">
+              @for (section of groupedResults(); track section.group) {
+                <div class="mb-4">
+                  <div class="px-2 pb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--cc-text-soft)]">{{ section.group }}</div>
+                  <div class="space-y-1">
+                    @for (item of section.items; track item.id; let idx = $index) {
+                      <button
+                        type="button"
+                        class="cc-command-palette-item"
+                        [class.cc-command-palette-item-active]="absoluteIndex(section.group, idx) === activeIndex()"
+                        (mouseenter)="activeIndex.set(absoluteIndex(section.group, idx))"
+                        (click)="select(item)"
+                      >
+                        <div class="min-w-0 flex-1 text-left">
+                          <div class="truncate text-sm font-semibold text-[var(--cc-text)]">{{ item.title }}</div>
+                          <div class="mt-1 truncate text-xs text-[var(--cc-text-soft)]">{{ item.subtitle }}</div>
+                        </div>
+                        <div class="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">{{ item.group }}</div>
+                      </button>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+          }
+        </section>
+      </div>
+    }
+  `,
+})
+export class CommandPaletteComponent {
+  readonly open = input(false);
+  readonly navItems = input<NavItem[]>([]);
+  readonly closed = output<void>();
+
+  private readonly router = inject(Router);
+  private readonly data = inject(DashboardDataService);
+  private readonly theme = inject(ThemeService);
+  private readonly inputRef = viewChild<ElementRef<HTMLInputElement>>('paletteInput');
+
+  protected readonly query = signal('');
+  protected readonly activeIndex = signal(0);
+
+  private readonly navCommands = computed<CommandPaletteItem[]>(() => this.navItems().map((item) => ({
+    id: `view:${item.path}`,
+    group: 'Views',
+    title: item.label,
+    subtitle: item.path === '/' ? 'Open Home' : `Navigate to ${item.path}`,
+    keywords: `${item.label} ${item.path}`.toLowerCase(),
+    run: () => {
+      void this.router.navigateByUrl(item.path);
+    },
+  })));
+
+  private readonly actionCommands = computed<CommandPaletteItem[]>(() => [
+    {
+      id: 'action:refresh-all',
+      group: 'Actions',
+      title: 'Refresh all sources',
+      subtitle: 'Kick every dashboard resource refresh now',
+      keywords: 'refresh all sources reload dashboard',
+      run: () => this.data.refreshAll(),
+    },
+    {
+      id: 'action:toggle-theme',
+      group: 'Actions',
+      title: `Switch to ${this.theme.theme() === 'dark' ? 'light' : 'dark'} mode`,
+      subtitle: 'Toggle the dashboard theme',
+      keywords: 'theme dark light toggle appearance',
+      run: () => this.theme.toggleTheme(),
+    },
+  ]);
+
+  private readonly repoCommands = computed<CommandPaletteItem[]>(() => this.repoItems(this.query(), this.data.repos().data() ?? []));
+  private readonly issueCommands = computed<CommandPaletteItem[]>(() => this.issueItems(this.query(), this.allIssues()));
+  private readonly prCommands = computed<CommandPaletteItem[]>(() => this.prItems(this.query(), this.data.prs().data() ?? []));
+
+  protected readonly flatResults = computed<CommandPaletteItem[]>(() => {
+    const q = this.query().trim().toLowerCase();
+    const nav = this.filterItems(this.navCommands(), q);
+    const actions = this.filterItems(this.actionCommands(), q);
+
+    if (!q) {
+      return [...actions, ...nav.slice(0, 8), ...this.repoCommands().slice(0, 4), ...this.issueCommands().slice(0, 4), ...this.prCommands().slice(0, 4)];
+    }
+
+    return [...actions, ...nav, ...this.repoCommands(), ...this.issueCommands(), ...this.prCommands()];
+  });
+
+  protected readonly groupedResults = computed(() => {
+    const groups: CommandPaletteItem['group'][] = ['Actions', 'Views', 'Repos', 'Issues', 'PRs'];
+    return groups
+      .map((group) => ({ group, items: this.flatResults().filter((item) => item.group === group) }))
+      .filter((section) => section.items.length > 0);
+  });
+
+  constructor() {
+    effect(() => {
+      if (!this.open()) return;
+      this.query.set('');
+      this.activeIndex.set(0);
+      queueMicrotask(() => this.inputRef()?.nativeElement.focus());
+    });
+
+    effect(() => {
+      const max = Math.max(0, this.flatResults().length - 1);
+      if (this.activeIndex() > max) this.activeIndex.set(max);
+    });
+  }
+
+  protected onQueryChange(value: string): void {
+    this.query.set(value);
+    this.activeIndex.set(0);
+  }
+
+  protected onInputKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.activeIndex.update((index) => Math.min(index + 1, Math.max(0, this.flatResults().length - 1)));
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeIndex.update((index) => Math.max(index - 1, 0));
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const item = this.flatResults()[this.activeIndex()];
+      if (item) this.select(item);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+    }
+  }
+
+  protected absoluteIndex(group: CommandPaletteItem['group'], indexWithinGroup: number): number {
+    let offset = 0;
+    for (const section of this.groupedResults()) {
+      if (section.group === group) return offset + indexWithinGroup;
+      offset += section.items.length;
+    }
+    return indexWithinGroup;
+  }
+
+  protected select(item: CommandPaletteItem): void {
+    item.run();
+    this.close();
+  }
+
+  protected close(): void {
+    this.closed.emit();
+  }
+
+  private allIssues(): IssueItem[] {
+    const data = this.data.issues().data();
+    if (!data) return [];
+    return [...data.urgent, ...data.active, ...data.deferred];
+  }
+
+  private filterItems(items: CommandPaletteItem[], query: string): CommandPaletteItem[] {
+    if (!query) return items;
+    return items.filter((item) => `${item.title} ${item.subtitle} ${item.keywords}`.toLowerCase().includes(query));
+  }
+
+  private repoItems(query: string, repos: RepoSummary[]): CommandPaletteItem[] {
+    const q = query.trim().toLowerCase();
+    const filtered = !q
+      ? repos.slice(0, 5)
+      : repos.filter((repo) => `${repo.repo} ${repo.repoFull}`.toLowerCase().includes(q)).slice(0, 6);
+
+    return filtered.map((repo) => ({
+      id: `repo:${repo.repoFull}`,
+      group: 'Repos',
+      title: repo.repo,
+      subtitle: `${repo.openIssues} open issues`,
+      keywords: `${repo.repo} ${repo.repoFull}`.toLowerCase(),
+      run: () => {
+        void this.router.navigate(['/issues/active'], { queryParams: { repo: repo.repo } });
+      },
+    }));
+  }
+
+  private issueItems(query: string, issues: IssueItem[]): CommandPaletteItem[] {
+    const q = query.trim().toLowerCase();
+    const filtered = !q
+      ? issues.slice(0, 5)
+      : issues.filter((issue) => `${issue.title} ${issue.repo} ${issue.number}`.toLowerCase().includes(q)).slice(0, 6);
+
+    return filtered.map((issue) => ({
+      id: `issue:${issue.repoFull}#${issue.number}`,
+      group: 'Issues',
+      title: issue.title,
+      subtitle: `${issue.repo} · #${issue.number}`,
+      keywords: `${issue.title} ${issue.repo} ${issue.number} ${issue.priority}`.toLowerCase(),
+      run: () => {
+        if (typeof window !== 'undefined') window.open(issue.url, '_blank', 'noopener');
+      },
+    }));
+  }
+
+  private prItems(query: string, prs: PullRequestItem[]): CommandPaletteItem[] {
+    const q = query.trim().toLowerCase();
+    const filtered = !q
+      ? prs.slice(0, 5)
+      : prs.filter((pr) => `${pr.title} ${pr.repo} ${pr.number} ${pr.headRefName}`.toLowerCase().includes(q)).slice(0, 6);
+
+    return filtered.map((pr) => ({
+      id: `pr:${pr.repoFull}#${pr.number}`,
+      group: 'PRs',
+      title: pr.title,
+      subtitle: `${pr.repo} · #${pr.number}`,
+      keywords: `${pr.title} ${pr.repo} ${pr.number} ${pr.headRefName}`.toLowerCase(),
+      run: () => {
+        if (typeof window !== 'undefined') window.open(pr.url, '_blank', 'noopener');
+      },
+    }));
+  }
+}

--- a/frontend/src/app/shared/ui/command-palette.component.ts
+++ b/frontend/src/app/shared/ui/command-palette.component.ts
@@ -6,13 +6,23 @@ import { ThemeService } from '../../core/theme/theme.service';
 import { IssueItem, PullRequestItem, RepoSummary } from '../../models/api';
 import { NavItem } from '../models/nav-item';
 
+type CommandGroup = 'Actions' | 'Views' | 'Repos' | 'Issues' | 'PRs';
+
 interface CommandPaletteItem {
   id: string;
-  group: 'Actions' | 'Views' | 'Repos' | 'Issues' | 'PRs';
+  group: CommandGroup;
   title: string;
   subtitle: string;
   keywords: string;
+  icon: string;
+  badge?: string;
+  emptyRank: number;
   run: () => void;
+}
+
+interface CommandSection {
+  group: CommandGroup;
+  items: CommandPaletteItem[];
 }
 
 @Component({
@@ -23,22 +33,29 @@ interface CommandPaletteItem {
       <div class="cc-command-palette-backdrop" (click)="close()">
         <section class="cc-command-palette-shell" (click)="$event.stopPropagation()">
           <div class="border-b border-[var(--cc-border)] px-4 py-4 sm:px-5">
-            <input
-              #paletteInput
-              [value]="query()"
-              (input)="onQueryChange($any($event.target).value)"
-              (keydown)="onInputKeydown($event)"
-              class="cc-command-palette-input"
-              placeholder="Jump to a view, repo, issue, PR, or action..."
-            />
+            <div class="flex items-center gap-3">
+              <div class="flex h-10 w-10 items-center justify-center rounded-2xl border border-[var(--cc-border)] bg-white/6 text-base text-[var(--cc-text-soft)]">⌘</div>
+              <div class="min-w-0 flex-1">
+                <input
+                  #paletteInput
+                  [value]="query()"
+                  (input)="onQueryChange($any($event.target).value)"
+                  (keydown)="onInputKeydown($event)"
+                  class="cc-command-palette-input"
+                  placeholder="Jump to a view, repo, issue, PR, or action..."
+                />
+                <div class="mt-1 text-xs text-[var(--cc-text-soft)]">Views, loaded GitHub objects, and quick actions in one place.</div>
+              </div>
+            </div>
           </div>
 
           @if (!flatResults().length) {
-            <div class="px-5 py-10 text-center text-sm text-[var(--cc-text-soft)]">
-              No commands match that search.
+            <div class="px-5 py-10 text-center">
+              <div class="text-sm font-semibold text-[var(--cc-text)]">No matches</div>
+              <div class="mt-1 text-sm text-[var(--cc-text-soft)]">Try a repo name, issue number, PR branch, or page title.</div>
             </div>
           } @else {
-            <div class="max-h-[70vh] overflow-y-auto px-3 py-3">
+            <div class="max-h-[68vh] overflow-y-auto px-3 py-3">
               @for (section of groupedResults(); track section.group) {
                 <div class="mb-4">
                   <div class="px-2 pb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--cc-text-soft)]">{{ section.group }}</div>
@@ -51,8 +68,14 @@ interface CommandPaletteItem {
                         (mouseenter)="activeIndex.set(absoluteIndex(section.group, idx))"
                         (click)="select(item)"
                       >
+                        <div class="cc-command-palette-icon">{{ item.icon }}</div>
                         <div class="min-w-0 flex-1 text-left">
-                          <div class="truncate text-sm font-semibold text-[var(--cc-text)]">{{ item.title }}</div>
+                          <div class="flex items-center gap-2">
+                            <div class="truncate text-sm font-semibold text-[var(--cc-text)]">{{ item.title }}</div>
+                            @if (item.badge) {
+                              <span class="cc-command-palette-badge">{{ item.badge }}</span>
+                            }
+                          </div>
                           <div class="mt-1 truncate text-xs text-[var(--cc-text-soft)]">{{ item.subtitle }}</div>
                         </div>
                         <div class="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">{{ item.group }}</div>
@@ -63,6 +86,12 @@ interface CommandPaletteItem {
               }
             </div>
           }
+
+          <div class="cc-command-palette-footer">
+            <span>↑ ↓ move</span>
+            <span>↵ open</span>
+            <span>esc close</span>
+          </div>
         </section>
       </div>
     }
@@ -81,12 +110,14 @@ export class CommandPaletteComponent {
   protected readonly query = signal('');
   protected readonly activeIndex = signal(0);
 
-  private readonly navCommands = computed<CommandPaletteItem[]>(() => this.navItems().map((item) => ({
+  private readonly navCommands = computed<CommandPaletteItem[]>(() => this.navItems().map((item, index) => ({
     id: `view:${item.path}`,
     group: 'Views',
     title: item.label,
-    subtitle: item.path === '/' ? 'Open Home' : `Navigate to ${item.path}`,
+    subtitle: item.path === '/' ? 'Open the main dashboard' : `Navigate to ${item.path}`,
     keywords: `${item.label} ${item.path}`.toLowerCase(),
+    icon: item.path === '/' ? '⌂' : '→',
+    emptyRank: 300 - index,
     run: () => {
       void this.router.navigateByUrl(item.path);
     },
@@ -98,7 +129,10 @@ export class CommandPaletteComponent {
       group: 'Actions',
       title: 'Refresh all sources',
       subtitle: 'Kick every dashboard resource refresh now',
-      keywords: 'refresh all sources reload dashboard',
+      keywords: 'refresh all sources reload dashboard sync update',
+      icon: '↻',
+      badge: 'Global',
+      emptyRank: 500,
       run: () => this.data.refreshAll(),
     },
     {
@@ -106,29 +140,38 @@ export class CommandPaletteComponent {
       group: 'Actions',
       title: `Switch to ${this.theme.theme() === 'dark' ? 'light' : 'dark'} mode`,
       subtitle: 'Toggle the dashboard theme',
-      keywords: 'theme dark light toggle appearance',
+      keywords: 'theme dark light toggle appearance mode',
+      icon: '◐',
+      badge: 'Theme',
+      emptyRank: 490,
       run: () => this.theme.toggleTheme(),
     },
   ]);
 
-  private readonly repoCommands = computed<CommandPaletteItem[]>(() => this.repoItems(this.query(), this.data.repos().data() ?? []));
-  private readonly issueCommands = computed<CommandPaletteItem[]>(() => this.issueItems(this.query(), this.allIssues()));
-  private readonly prCommands = computed<CommandPaletteItem[]>(() => this.prItems(this.query(), this.data.prs().data() ?? []));
+  private readonly repoCommands = computed<CommandPaletteItem[]>(() => this.repoItems(this.data.repos().data() ?? []));
+  private readonly issueCommands = computed<CommandPaletteItem[]>(() => this.issueItems(this.allIssues()));
+  private readonly prCommands = computed<CommandPaletteItem[]>(() => this.prItems(this.data.prs().data() ?? []));
 
   protected readonly flatResults = computed<CommandPaletteItem[]>(() => {
     const q = this.query().trim().toLowerCase();
-    const nav = this.filterItems(this.navCommands(), q);
-    const actions = this.filterItems(this.actionCommands(), q);
+    const items = [
+      ...this.actionCommands(),
+      ...this.navCommands(),
+      ...this.repoCommands(),
+      ...this.issueCommands(),
+      ...this.prCommands(),
+    ];
 
-    if (!q) {
-      return [...actions, ...nav.slice(0, 8), ...this.repoCommands().slice(0, 4), ...this.issueCommands().slice(0, 4), ...this.prCommands().slice(0, 4)];
-    }
-
-    return [...actions, ...nav, ...this.repoCommands(), ...this.issueCommands(), ...this.prCommands()];
+    return items
+      .map((item) => ({ item, score: this.scoreItem(item, q) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score || a.item.title.localeCompare(b.item.title))
+      .slice(0, q ? 18 : 14)
+      .map((entry) => entry.item);
   });
 
-  protected readonly groupedResults = computed(() => {
-    const groups: CommandPaletteItem['group'][] = ['Actions', 'Views', 'Repos', 'Issues', 'PRs'];
+  protected readonly groupedResults = computed<CommandSection[]>(() => {
+    const groups: CommandGroup[] = ['Actions', 'Views', 'Repos', 'Issues', 'PRs'];
     return groups
       .map((group) => ({ group, items: this.flatResults().filter((item) => item.group === group) }))
       .filter((section) => section.items.length > 0);
@@ -179,7 +222,7 @@ export class CommandPaletteComponent {
     }
   }
 
-  protected absoluteIndex(group: CommandPaletteItem['group'], indexWithinGroup: number): number {
+  protected absoluteIndex(group: CommandGroup, indexWithinGroup: number): number {
     let offset = 0;
     for (const section of this.groupedResults()) {
       if (section.group === group) return offset + indexWithinGroup;
@@ -203,59 +246,69 @@ export class CommandPaletteComponent {
     return [...data.urgent, ...data.active, ...data.deferred];
   }
 
-  private filterItems(items: CommandPaletteItem[], query: string): CommandPaletteItem[] {
-    if (!query) return items;
-    return items.filter((item) => `${item.title} ${item.subtitle} ${item.keywords}`.toLowerCase().includes(query));
+  private scoreItem(item: CommandPaletteItem, query: string): number {
+    if (!query) return item.emptyRank;
+
+    const haystack = `${item.title} ${item.subtitle} ${item.keywords}`.toLowerCase();
+    const title = item.title.toLowerCase();
+    const tokens = query.split(/\s+/).filter(Boolean);
+    if (!tokens.length) return item.emptyRank;
+
+    let score = 0;
+    for (const token of tokens) {
+      if (title === token) score += 120;
+      else if (title.startsWith(token)) score += 70;
+      else if (title.includes(token)) score += 40;
+      else if (haystack.includes(token)) score += 18;
+      else return 0;
+    }
+
+    if (haystack.includes(query)) score += 30;
+    return score + item.emptyRank / 10;
   }
 
-  private repoItems(query: string, repos: RepoSummary[]): CommandPaletteItem[] {
-    const q = query.trim().toLowerCase();
-    const filtered = !q
-      ? repos.slice(0, 5)
-      : repos.filter((repo) => `${repo.repo} ${repo.repoFull}`.toLowerCase().includes(q)).slice(0, 6);
-
-    return filtered.map((repo) => ({
+  private repoItems(repos: RepoSummary[]): CommandPaletteItem[] {
+    return repos.map((repo) => ({
       id: `repo:${repo.repoFull}`,
       group: 'Repos',
       title: repo.repo,
-      subtitle: `${repo.openIssues} open issues`,
-      keywords: `${repo.repo} ${repo.repoFull}`.toLowerCase(),
+      subtitle: `${repo.repoFull} · ${repo.openIssues} open issues`,
+      keywords: `${repo.repo} ${repo.repoFull} repository issues backlog`.toLowerCase(),
+      icon: '□',
+      badge: repo.archived ? 'Archived' : repo.tracked ? 'Tracked' : undefined,
+      emptyRank: 200 + Math.min(repo.openIssues, 20),
       run: () => {
         void this.router.navigate(['/issues/active'], { queryParams: { repo: repo.repo } });
       },
     }));
   }
 
-  private issueItems(query: string, issues: IssueItem[]): CommandPaletteItem[] {
-    const q = query.trim().toLowerCase();
-    const filtered = !q
-      ? issues.slice(0, 5)
-      : issues.filter((issue) => `${issue.title} ${issue.repo} ${issue.number}`.toLowerCase().includes(q)).slice(0, 6);
-
-    return filtered.map((issue) => ({
+  private issueItems(issues: IssueItem[]): CommandPaletteItem[] {
+    return issues.map((issue) => ({
       id: `issue:${issue.repoFull}#${issue.number}`,
       group: 'Issues',
       title: issue.title,
       subtitle: `${issue.repo} · #${issue.number}`,
-      keywords: `${issue.title} ${issue.repo} ${issue.number} ${issue.priority}`.toLowerCase(),
+      keywords: `${issue.title} ${issue.repo} ${issue.repoFull} ${issue.number} ${issue.priority} issue`.toLowerCase(),
+      icon: '!',
+      badge: issue.priority,
+      emptyRank: issue.priority === 'urgent' ? 180 : issue.priority === 'active' ? 150 : 120,
       run: () => {
         if (typeof window !== 'undefined') window.open(issue.url, '_blank', 'noopener');
       },
     }));
   }
 
-  private prItems(query: string, prs: PullRequestItem[]): CommandPaletteItem[] {
-    const q = query.trim().toLowerCase();
-    const filtered = !q
-      ? prs.slice(0, 5)
-      : prs.filter((pr) => `${pr.title} ${pr.repo} ${pr.number} ${pr.headRefName}`.toLowerCase().includes(q)).slice(0, 6);
-
-    return filtered.map((pr) => ({
+  private prItems(prs: PullRequestItem[]): CommandPaletteItem[] {
+    return prs.map((pr) => ({
       id: `pr:${pr.repoFull}#${pr.number}`,
       group: 'PRs',
       title: pr.title,
-      subtitle: `${pr.repo} · #${pr.number}`,
-      keywords: `${pr.title} ${pr.repo} ${pr.number} ${pr.headRefName}`.toLowerCase(),
+      subtitle: `${pr.repo} · #${pr.number} · ${pr.headRefName}`,
+      keywords: `${pr.title} ${pr.repo} ${pr.repoFull} ${pr.number} ${pr.headRefName} pull request`.toLowerCase(),
+      icon: pr.isDraft ? '◌' : '⇅',
+      badge: pr.reviewDecision || (pr.isDraft ? 'Draft' : 'Open'),
+      emptyRank: pr.reviewDecision === 'CHANGES_REQUESTED' ? 175 : pr.reviewDecision === 'REVIEW_REQUIRED' ? 165 : 130,
       run: () => {
         if (typeof window !== 'undefined') window.open(pr.url, '_blank', 'noopener');
       },

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -343,3 +343,56 @@ code {
   background: rgba(99, 102, 241, 0.14);
   color: #dbeafe;
 }
+
+.cc-command-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 5rem 1rem 2rem;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(14px);
+}
+
+.cc-command-palette-shell {
+  width: min(52rem, 100%);
+  overflow: hidden;
+  border: 1px solid var(--cc-border);
+  border-radius: 1.75rem;
+  background: color-mix(in srgb, var(--cc-surface) 94%, #020617 6%);
+  box-shadow: 0 40px 120px rgba(2, 6, 23, 0.5);
+}
+
+.cc-command-palette-input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--cc-text);
+  font-size: 1rem;
+  line-height: 1.5rem;
+  outline: none;
+}
+
+.cc-command-palette-input::placeholder {
+  color: var(--cc-text-soft);
+}
+
+.cc-command-palette-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 1rem;
+  border: 1px solid transparent;
+  border-radius: 1rem;
+  padding: 0.85rem 0.9rem;
+  background: transparent;
+  transition: 160ms ease;
+}
+
+.cc-command-palette-item:hover,
+.cc-command-palette-item-active {
+  border-color: rgba(99, 102, 241, 0.24);
+  background: rgba(99, 102, 241, 0.12);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -396,3 +396,43 @@ code {
   border-color: rgba(99, 102, 241, 0.24);
   background: rgba(99, 102, 241, 0.12);
 }
+
+.cc-command-palette-icon {
+  display: inline-flex;
+  height: 2.4rem;
+  width: 2.4rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.95rem;
+  border: 1px solid var(--cc-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--cc-text-soft);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.cc-command-palette-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid var(--cc-border);
+  padding: 0.2rem 0.5rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cc-text-soft);
+}
+
+.cc-command-palette-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  border-top: 1px solid var(--cc-border);
+  padding: 0.9rem 1.25rem 1rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cc-text-soft);
+}


### PR DESCRIPTION
## Summary
- add a shell-level command palette with a sidebar launcher and Cmd/Ctrl+K shortcut
- support keyboard navigation plus view, repo, issue, PR, and quick-action results
- polish ranking and presentation so the palette feels usable as a real quick switcher

## Testing
- npm test

Part of #63.
