### PR TITLE
Add contextual palette actions and lightweight trend bars

### DIFF
--- a/frontend/src/app/features/analytics/analytics.page.ts
+++ b/frontend/src/app/features/analytics/analytics.page.ts
@@ -5,10 +5,11 @@ import { ViewShellComponent } from '../../layout/view-shell.component';
 import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
 import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+import { TrendBarsComponent } from '../../shared/ui/trend-bars.component';
 
 @Component({
   selector: 'app-analytics-page',
-  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, StatePanelComponent, TrendBarsComponent],
   template: `
     <app-view-shell eyebrow="Analytics" title="Analytics" subtitle="Traffic summary and site-level metrics." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
@@ -23,10 +24,38 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
         <cc-state-panel kind="empty" title="No analytics data" message="No analytics site rows were returned for the current range."></cc-state-panel>
       } @else {
         <section class="grid gap-4 md:grid-cols-4">
-          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Page Views</div><div class="mt-3 text-3xl font-semibold text-amber-300">{{ analytics.data()!.totals.pageviews.toLocaleString() }}</div></div>
-          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Unique Visitors</div><div class="mt-3 text-3xl font-semibold text-sky-300">{{ analytics.data()!.totals.visitors.toLocaleString() }}</div></div>
-          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Sessions</div><div class="mt-3 text-3xl font-semibold text-emerald-300">{{ analytics.data()!.totals.visits.toLocaleString() }}</div></div>
-          <div class="cc-list-card p-5"><div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Avg Bounce</div><div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ averageBounce() }}%</div></div>
+          <div class="cc-list-card p-5">
+            <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Page Views</div>
+            <div class="mt-3 text-3xl font-semibold text-amber-300">{{ analytics.data()!.totals.pageviews.toLocaleString() }}</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="pageviewMix()" tone="amber"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">top-site mix</div>
+            </div>
+          </div>
+          <div class="cc-list-card p-5">
+            <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Unique Visitors</div>
+            <div class="mt-3 text-3xl font-semibold text-sky-300">{{ analytics.data()!.totals.visitors.toLocaleString() }}</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="visitorMix()" tone="sky"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">top-site mix</div>
+            </div>
+          </div>
+          <div class="cc-list-card p-5">
+            <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Sessions</div>
+            <div class="mt-3 text-3xl font-semibold text-emerald-300">{{ analytics.data()!.totals.visits.toLocaleString() }}</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="visitMix()" tone="emerald"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">top-site mix</div>
+            </div>
+          </div>
+          <div class="cc-list-card p-5">
+            <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Avg Bounce</div>
+            <div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ averageBounce() }}%</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="bounceMix()" tone="fuchsia"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">property spread</div>
+            </div>
+          </div>
         </section>
 
         <section class="cc-table-shell">
@@ -77,6 +106,10 @@ export class AnalyticsPage {
     if (!totals || totals.visits === 0) return 0;
     return Math.round((totals.bounces / totals.visits) * 100);
   });
+  protected readonly pageviewMix = computed(() => this.topSiteValues((site) => site.pageviews));
+  protected readonly visitorMix = computed(() => this.topSiteValues((site) => site.visitors));
+  protected readonly visitMix = computed(() => this.topSiteValues((site) => site.visits));
+  protected readonly bounceMix = computed(() => this.topSiteValues((site) => this.siteBounce(site)));
   protected readonly meta = computed(() => {
     const count = this.analytics.data()?.sites.length ?? 0;
     const summary = `Last 30 days · ${count} properties`;
@@ -97,6 +130,10 @@ export class AnalyticsPage {
   private async copyLink(): Promise<void> {
     if (typeof window === 'undefined' || !navigator?.clipboard) return;
     await navigator.clipboard.writeText(window.location.href);
+  }
+
+  private topSiteValues(pick: (site: { pageviews: number; visitors: number; visits: number; bounces: number; totaltime: number }) => number): number[] {
+    return (this.analytics.data()?.sites ?? []).slice(0, 7).map((site) => pick(site));
   }
 
   protected shareOfPageviews(pageviews: number): number {

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -12,6 +12,7 @@ import { CardComponent } from '../../shared/ui/card.component';
 import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+import { TrendBarsComponent } from '../../shared/ui/trend-bars.component';
 
 interface PinnedHomeItem {
   type: 'Issue' | 'PR' | 'Task' | 'Event' | 'Repo';
@@ -24,7 +25,7 @@ interface PinnedHomeItem {
 
 @Component({
   selector: 'app-home-page',
-  imports: [ViewShellComponent, CardComponent, PanelActionsComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, CardComponent, PanelActionsComponent, PillComponent, StatePanelComponent, TrendBarsComponent],
   template: `
     <app-view-shell
       eyebrow="Overview"
@@ -43,21 +44,37 @@ interface PinnedHomeItem {
           <button type="button" (click)="go('/issues/urgent')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Urgent</div>
             <div class="mt-3 text-3xl font-semibold text-rose-300">{{ issues.data()?.counts?.urgent ?? 0 }}</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="urgentIssueTrend()" tone="rose"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">7d new issues</div>
+            </div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">bugs and critical work</div>
           </button>
           <button type="button" (click)="go('/issues/active')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Active</div>
             <div class="mt-3 text-3xl font-semibold text-amber-300">{{ issues.data()?.counts?.active ?? 0 }}</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="activeIssueTrend()" tone="amber"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">7d new issues</div>
+            </div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">in-progress issues</div>
           </button>
           <button type="button" (click)="go('/issues/backlog')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Backlog</div>
             <div class="mt-3 text-3xl font-semibold text-slate-300">{{ issues.data()?.counts?.deferred ?? 0 }}</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="backlogIssueTrend()" tone="slate"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">7d new issues</div>
+            </div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ issues.data()?.total ?? 0 }} total open</div>
           </button>
           <button type="button" (click)="go('/tasks')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Tasks</div>
             <div class="mt-3 text-3xl font-semibold text-fuchsia-300">{{ tasks.data()?.open?.length ?? 0 }}</div>
+            <div class="mt-3 flex items-end gap-3">
+              <cc-trend-bars [values]="taskCompletionTrend()" tone="fuchsia"></cc-trend-bars>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">7d completions</div>
+            </div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">open in Obsidian</div>
           </button>
           <button type="button" (click)="go('/infra')" class="cc-card-button p-5 text-left">
@@ -355,6 +372,10 @@ export class HomePage {
     return [...pinned, ...recent].slice(0, 6);
   });
   protected readonly homeTasks = computed(() => (this.tasks.data()?.open ?? []).slice(0, 4));
+  protected readonly urgentIssueTrend = computed(() => this.dailyCountTrend((this.issues.data()?.urgent ?? []).map((issue) => issue.createdAt)));
+  protected readonly activeIssueTrend = computed(() => this.dailyCountTrend((this.issues.data()?.active ?? []).map((issue) => issue.createdAt)));
+  protected readonly backlogIssueTrend = computed(() => this.dailyCountTrend((this.issues.data()?.deferred ?? []).map((issue) => issue.createdAt)));
+  protected readonly taskCompletionTrend = computed(() => this.dailyCountTrend((this.tasks.data()?.completed ?? []).map((task) => task.completedAt).filter(Boolean) as string[]));
   protected readonly hiddenSections = computed(() => this.homeLayout.layout().hidden);
   protected readonly pinnedHomeItems = computed<PinnedHomeItem[]>(() => {
     const items: PinnedHomeItem[] = [];
@@ -475,6 +496,23 @@ export class HomePage {
 
   protected go(path: string): void {
     this.router.navigateByUrl(path);
+  }
+
+  private dailyCountTrend(values: string[], days = 7): number[] {
+    const buckets = Array.from({ length: days }, () => 0);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    for (const value of values) {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) continue;
+      date.setHours(0, 0, 0, 0);
+      const diff = Math.floor((today.getTime() - date.getTime()) / 86400000);
+      if (diff < 0 || diff >= days) continue;
+      buckets[days - diff - 1] += 1;
+    }
+
+    return buckets;
   }
 
   protected sectionLabel(sectionId: string): string {

--- a/frontend/src/app/shared/ui/command-palette.component.ts
+++ b/frontend/src/app/shared/ui/command-palette.component.ts
@@ -123,30 +123,140 @@ export class CommandPaletteComponent {
     },
   })));
 
-  private readonly actionCommands = computed<CommandPaletteItem[]>(() => [
-    {
-      id: 'action:refresh-all',
-      group: 'Actions',
-      title: 'Refresh all sources',
-      subtitle: 'Kick every dashboard resource refresh now',
-      keywords: 'refresh all sources reload dashboard sync update',
-      icon: '↻',
-      badge: 'Global',
-      emptyRank: 500,
-      run: () => this.data.refreshAll(),
-    },
-    {
-      id: 'action:toggle-theme',
-      group: 'Actions',
-      title: `Switch to ${this.theme.theme() === 'dark' ? 'light' : 'dark'} mode`,
-      subtitle: 'Toggle the dashboard theme',
-      keywords: 'theme dark light toggle appearance mode',
-      icon: '◐',
-      badge: 'Theme',
-      emptyRank: 490,
-      run: () => this.theme.toggleTheme(),
-    },
-  ]);
+  private readonly actionCommands = computed<CommandPaletteItem[]>(() => {
+    const actions: CommandPaletteItem[] = [
+      {
+        id: 'action:refresh-all',
+        group: 'Actions',
+        title: 'Refresh all sources',
+        subtitle: 'Kick every dashboard resource refresh now',
+        keywords: 'refresh all sources reload dashboard sync update',
+        icon: '↻',
+        badge: 'Global',
+        emptyRank: 500,
+        run: () => this.data.refreshAll(),
+      },
+      {
+        id: 'action:toggle-theme',
+        group: 'Actions',
+        title: `Switch to ${this.theme.theme() === 'dark' ? 'light' : 'dark'} mode`,
+        subtitle: 'Toggle the dashboard theme',
+        keywords: 'theme dark light toggle appearance mode',
+        icon: '◐',
+        badge: 'Theme',
+        emptyRank: 490,
+        run: () => this.theme.toggleTheme(),
+      },
+    ];
+
+    const query = this.query().trim().toLowerCase();
+    if (!query) return actions;
+
+    const repo = this.bestMatch(this.repoCommands(), query);
+    if (repo) {
+      actions.push(
+        {
+          id: `action:repo-active:${repo.id}`,
+          group: 'Actions',
+          title: `Open active issues for ${repo.title}`,
+          subtitle: `Jump into the ${repo.title} active queue`,
+          keywords: `${repo.title} repo active issues queue open`.toLowerCase(),
+          icon: '→',
+          badge: 'Repo',
+          emptyRank: 470,
+          run: repo.run,
+        },
+        {
+          id: `action:repo-backlog:${repo.id}`,
+          group: 'Actions',
+          title: `Open backlog for ${repo.title}`,
+          subtitle: `Filter the backlog view down to ${repo.title}`,
+          keywords: `${repo.title} repo backlog deferred`.toLowerCase(),
+          icon: '⋯',
+          badge: 'Repo',
+          emptyRank: 460,
+          run: () => {
+            void this.router.navigate(['/issues/backlog'], { queryParams: { repo: repo.title } });
+          },
+        },
+        {
+          id: `action:repo-copy:${repo.id}`,
+          group: 'Actions',
+          title: `Copy repo filter for ${repo.title}`,
+          subtitle: 'Copy the short repo name for filtering and quick search',
+          keywords: `${repo.title} repo copy filter`.toLowerCase(),
+          icon: '⧉',
+          badge: 'Copy',
+          emptyRank: 450,
+          run: () => {
+            void this.copyToClipboard(repo.title);
+          },
+        },
+      );
+    }
+
+    const issue = this.bestMatch(this.issueCommands(), query);
+    if (issue) {
+      actions.push(
+        {
+          id: `action:issue-open:${issue.id}`,
+          group: 'Actions',
+          title: `Open ${issue.subtitle}`,
+          subtitle: issue.title,
+          keywords: `${issue.title} ${issue.subtitle} open github issue`.toLowerCase(),
+          icon: '!',
+          badge: 'Issue',
+          emptyRank: 445,
+          run: issue.run,
+        },
+        {
+          id: `action:issue-copy:${issue.id}`,
+          group: 'Actions',
+          title: `Copy link for ${issue.subtitle}`,
+          subtitle: issue.title,
+          keywords: `${issue.title} ${issue.subtitle} copy link issue`.toLowerCase(),
+          icon: '⧉',
+          badge: 'Copy',
+          emptyRank: 440,
+          run: () => {
+            void this.copyToClipboard(this.objectUrl(issue.id));
+          },
+        },
+      );
+    }
+
+    const pr = this.bestMatch(this.prCommands(), query);
+    if (pr) {
+      actions.push(
+        {
+          id: `action:pr-open:${pr.id}`,
+          group: 'Actions',
+          title: `Open ${pr.subtitle}`,
+          subtitle: pr.title,
+          keywords: `${pr.title} ${pr.subtitle} open github pr pull request`.toLowerCase(),
+          icon: '⇅',
+          badge: 'PR',
+          emptyRank: 435,
+          run: pr.run,
+        },
+        {
+          id: `action:pr-copy:${pr.id}`,
+          group: 'Actions',
+          title: `Copy link for ${pr.subtitle}`,
+          subtitle: pr.title,
+          keywords: `${pr.title} ${pr.subtitle} copy link pr pull request`.toLowerCase(),
+          icon: '⧉',
+          badge: 'Copy',
+          emptyRank: 430,
+          run: () => {
+            void this.copyToClipboard(this.objectUrl(pr.id));
+          },
+        },
+      );
+    }
+
+    return actions;
+  });
 
   private readonly repoCommands = computed<CommandPaletteItem[]>(() => this.repoItems(this.data.repos().data() ?? []));
   private readonly issueCommands = computed<CommandPaletteItem[]>(() => this.issueItems(this.allIssues()));
@@ -265,6 +375,26 @@ export class CommandPaletteComponent {
 
     if (haystack.includes(query)) score += 30;
     return score + item.emptyRank / 10;
+  }
+
+  private bestMatch(items: CommandPaletteItem[], query: string): CommandPaletteItem | null {
+    return items
+      .map((item) => ({ item, score: this.scoreItem(item, query) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)[0]?.item ?? null;
+  }
+
+  private objectUrl(id: string): string {
+    const [, repoAndNumber] = id.split(':');
+    if (!repoAndNumber) return '';
+    const [repoFull, number] = repoAndNumber.split('#');
+    if (!repoFull || !number) return '';
+    return `https://github.com/${repoFull}/${id.startsWith('pr:') ? 'pull' : 'issues'}/${number}`;
+  }
+
+  private async copyToClipboard(value: string): Promise<void> {
+    if (!value || typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(value);
   }
 
   private repoItems(repos: RepoSummary[]): CommandPaletteItem[] {

--- a/frontend/src/app/shared/ui/trend-bars.component.ts
+++ b/frontend/src/app/shared/ui/trend-bars.component.ts
@@ -1,0 +1,26 @@
+import { Component, computed, input } from '@angular/core';
+
+@Component({
+  selector: 'cc-trend-bars',
+  standalone: true,
+  template: `
+    <div class="cc-trend-bars" [class.cc-trend-bars-compact]="compact()" [attr.data-tone]="tone()">
+      @for (value of normalizedValues(); track $index) {
+        <span class="cc-trend-bar" [style.height.%]="value"></span>
+      }
+    </div>
+  `,
+})
+export class TrendBarsComponent {
+  readonly values = input<number[]>([]);
+  readonly tone = input<'rose' | 'amber' | 'slate' | 'fuchsia' | 'emerald' | 'sky'>('sky');
+  readonly compact = input(true);
+
+  protected readonly normalizedValues = computed(() => {
+    const values = this.values().map((value) => Math.max(0, value));
+    const max = Math.max(...values, 0);
+    if (!values.length) return [22, 22, 22, 22, 22, 22, 22];
+    if (max === 0) return values.map(() => 22);
+    return values.map((value) => Math.max(18, Math.round((value / max) * 100)));
+  });
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -436,3 +436,47 @@ code {
   text-transform: uppercase;
   color: var(--cc-text-soft);
 }
+
+.cc-trend-bars {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 0.28rem;
+  height: 2rem;
+}
+
+.cc-trend-bars-compact {
+  height: 1.7rem;
+}
+
+.cc-trend-bar {
+  width: 0.34rem;
+  min-height: 0.35rem;
+  border-radius: 9999px;
+  background: var(--cc-trend-color, rgba(125, 211, 252, 0.9));
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.04);
+  opacity: 0.92;
+}
+
+.cc-trend-bars[data-tone='rose'] {
+  --cc-trend-color: rgba(251, 113, 133, 0.95);
+}
+
+.cc-trend-bars[data-tone='amber'] {
+  --cc-trend-color: rgba(252, 211, 77, 0.95);
+}
+
+.cc-trend-bars[data-tone='slate'] {
+  --cc-trend-color: rgba(148, 163, 184, 0.95);
+}
+
+.cc-trend-bars[data-tone='fuchsia'] {
+  --cc-trend-color: rgba(232, 121, 249, 0.95);
+}
+
+.cc-trend-bars[data-tone='emerald'] {
+  --cc-trend-color: rgba(52, 211, 153, 0.95);
+}
+
+.cc-trend-bars[data-tone='sky'] {
+  --cc-trend-color: rgba(56, 189, 248, 0.95);
+}


### PR DESCRIPTION
## Summary
- add contextual command palette actions for matched repos, issues, and PRs
- introduce reusable lightweight trend bars and apply them to the Home summary cards
- extend the same lightweight trend treatment into the analytics summary cards

## Testing
- npm test

Part of #63.
Part of #62.
