### PR TITLE
Add OpenClaw runtime health panel

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { HomePage } from './features/home/home.page';
 import { InfraPage } from './features/infra/infra.page';
 import { IssueListPage } from './features/issues/issue-list.page';
 import { NotesPage } from './features/notes/notes.page';
+import { OpenClawPage } from './features/openclaw/openclaw.page';
 import { PrsPage } from './features/prs/prs.page';
 import { ReposPage } from './features/repos/repos.page';
 import { DonePage } from './features/tasks/done.page';
@@ -84,6 +85,11 @@ export const routes: Routes = [
     path: 'infra',
     component: InfraPage,
     title: 'Infrastructure',
+  },
+  {
+    path: 'openclaw',
+    component: OpenClawPage,
+    title: 'OpenClaw Runtime',
   },
   {
     path: 'analytics',

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -22,6 +22,7 @@ export class App {
     { path: '/calendar', label: 'Calendar' },
     { path: '/repos', label: 'Repos' },
     { path: '/infra', label: 'Infra' },
+    { path: '/openclaw', label: 'OpenClaw' },
     { path: '/analytics', label: 'Analytics' },
   ];
 }

--- a/frontend/src/app/core/api/command-center-api.service.ts
+++ b/frontend/src/app/core/api/command-center-api.service.ts
@@ -9,6 +9,7 @@ import {
   InfraResponse,
   IssuesResponse,
   NotesResponse,
+  OpenClawResponse,
   PrsResponse,
   RefreshResponse,
   ReposResponse,
@@ -54,6 +55,10 @@ export class CommandCenterApiService {
 
   getNotes(): Observable<NotesResponse> {
     return this.http.get<NotesResponse>('/api/notes');
+  }
+
+  getOpenClaw(): Observable<OpenClawResponse> {
+    return this.http.get<OpenClawResponse>('/api/openclaw');
   }
 
   refreshAll(): Observable<RefreshResponse> {

--- a/frontend/src/app/core/data/dashboard-data.service.ts
+++ b/frontend/src/app/core/data/dashboard-data.service.ts
@@ -9,6 +9,7 @@ import {
   IssuesResponse,
   IssuesViewModel,
   NotesResponse,
+  OpenClawResponse,
   PrsResponse,
   ReposResponse,
   StandupResponse,
@@ -32,6 +33,19 @@ export class DashboardDataService {
   private standupResource?: DashboardResource<StandupResponse['standup']>;
   private analyticsResource?: DashboardResource<{ totals: AnalyticsResponse['totals']; sites: AnalyticsResponse['sites']; range: AnalyticsResponse['range']; updatedAt: AnalyticsResponse['updatedAt'] }>;
   private notesResource?: DashboardResource<{ dailyNote: NotesResponse['dailyNote']; decisions: NotesResponse['decisions'] }>;
+  private openClawResource?: DashboardResource<{
+    version: OpenClawResponse['version'];
+    gateway: OpenClawResponse['gateway'];
+    gatewayService: OpenClawResponse['gatewayService'];
+    nodeService: OpenClawResponse['nodeService'];
+    agents: OpenClawResponse['agents'];
+    memoryPlugin: OpenClawResponse['memoryPlugin'];
+    updateAvailable: OpenClawResponse['updateAvailable'];
+    updateChannel: OpenClawResponse['updateChannel'];
+    updateInfo: OpenClawResponse['updateInfo'];
+    secretDiagnostics: OpenClawResponse['secretDiagnostics'];
+    updatedAt: OpenClawResponse['updatedAt'];
+  }>;
 
   issues(): DashboardResource<IssuesViewModel> {
     return this.issuesResource ??= createDashboardResource({
@@ -126,6 +140,39 @@ export class DashboardDataService {
     });
   }
 
+  openClaw(): DashboardResource<{
+    version: OpenClawResponse['version'];
+    gateway: OpenClawResponse['gateway'];
+    gatewayService: OpenClawResponse['gatewayService'];
+    nodeService: OpenClawResponse['nodeService'];
+    agents: OpenClawResponse['agents'];
+    memoryPlugin: OpenClawResponse['memoryPlugin'];
+    updateAvailable: OpenClawResponse['updateAvailable'];
+    updateChannel: OpenClawResponse['updateChannel'];
+    updateInfo: OpenClawResponse['updateInfo'];
+    secretDiagnostics: OpenClawResponse['secretDiagnostics'];
+    updatedAt: OpenClawResponse['updatedAt'];
+  }> {
+    return this.openClawResource ??= createDashboardResource({
+      load: () => this.api.getOpenClaw(),
+      selectData: (response: OpenClawResponse) => ({
+        version: response.version,
+        gateway: response.gateway,
+        gatewayService: response.gatewayService,
+        nodeService: response.nodeService,
+        agents: response.agents,
+        memoryPlugin: response.memoryPlugin,
+        updateAvailable: response.updateAvailable,
+        updateChannel: response.updateChannel,
+        updateInfo: response.updateInfo,
+        secretDiagnostics: response.secretDiagnostics,
+        updatedAt: response.updatedAt,
+      }),
+      isEmpty: () => false,
+      intervalMs: 60_000,
+    });
+  }
+
   closeIssue(repoFull: string, number: number): void {
     const [owner, repo] = repoFull.split('/');
     if (!owner || !repo) return;
@@ -164,5 +211,6 @@ export class DashboardDataService {
     this.standupResource?.refresh();
     this.analyticsResource?.refresh();
     this.notesResource?.refresh();
+    this.openClawResource?.refresh();
   }
 }

--- a/frontend/src/app/core/data/dashboard-data.service.ts
+++ b/frontend/src/app/core/data/dashboard-data.service.ts
@@ -37,9 +37,15 @@ export class DashboardDataService {
     version: OpenClawResponse['version'];
     gateway: OpenClawResponse['gateway'];
     gatewayService: OpenClawResponse['gatewayService'];
+    gatewayProcess: OpenClawResponse['gatewayProcess'];
     nodeService: OpenClawResponse['nodeService'];
     agents: OpenClawResponse['agents'];
+    sessions: OpenClawResponse['sessions'];
+    memory: OpenClawResponse['memory'];
     memoryPlugin: OpenClawResponse['memoryPlugin'];
+    tasks: OpenClawResponse['tasks'];
+    taskAudit: OpenClawResponse['taskAudit'];
+    channelSummary: OpenClawResponse['channelSummary'];
     updateAvailable: OpenClawResponse['updateAvailable'];
     updateChannel: OpenClawResponse['updateChannel'];
     updateInfo: OpenClawResponse['updateInfo'];
@@ -144,9 +150,15 @@ export class DashboardDataService {
     version: OpenClawResponse['version'];
     gateway: OpenClawResponse['gateway'];
     gatewayService: OpenClawResponse['gatewayService'];
+    gatewayProcess: OpenClawResponse['gatewayProcess'];
     nodeService: OpenClawResponse['nodeService'];
     agents: OpenClawResponse['agents'];
+    sessions: OpenClawResponse['sessions'];
+    memory: OpenClawResponse['memory'];
     memoryPlugin: OpenClawResponse['memoryPlugin'];
+    tasks: OpenClawResponse['tasks'];
+    taskAudit: OpenClawResponse['taskAudit'];
+    channelSummary: OpenClawResponse['channelSummary'];
     updateAvailable: OpenClawResponse['updateAvailable'];
     updateChannel: OpenClawResponse['updateChannel'];
     updateInfo: OpenClawResponse['updateInfo'];
@@ -159,9 +171,15 @@ export class DashboardDataService {
         version: response.version,
         gateway: response.gateway,
         gatewayService: response.gatewayService,
+        gatewayProcess: response.gatewayProcess,
         nodeService: response.nodeService,
         agents: response.agents,
+        sessions: response.sessions,
+        memory: response.memory,
         memoryPlugin: response.memoryPlugin,
+        tasks: response.tasks,
+        taskAudit: response.taskAudit,
+        channelSummary: response.channelSummary,
         updateAvailable: response.updateAvailable,
         updateChannel: response.updateChannel,
         updateInfo: response.updateInfo,

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -40,7 +40,7 @@ interface PinnedHomeItem {
       </div>
 
       <cc-card eyebrow="Today" title="command.center" [description]="tagline()" tone="highlight" [compact]="true">
-        <section class="grid gap-4 lg:grid-cols-5">
+        <section class="grid gap-4 lg:grid-cols-6">
           <button type="button" (click)="go('/issues/urgent')" class="cc-card-button p-5 text-left">
             <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">Urgent</div>
             <div class="mt-3 text-3xl font-semibold text-rose-300">{{ issues.data()?.counts?.urgent ?? 0 }}</div>
@@ -85,6 +85,16 @@ interface PinnedHomeItem {
             } @else {
               <div class="mt-3 text-3xl font-semibold text-[var(--cc-text-soft)]">—</div>
               <div class="mt-2 text-sm text-[var(--cc-text-muted)]">monitoring unavailable</div>
+            }
+          </button>
+          <button type="button" (click)="go('/openclaw')" class="cc-card-button p-5 text-left">
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--cc-text-soft)]">OpenClaw</div>
+            @if (openClaw.hasData()) {
+              <div class="mt-3 text-3xl font-semibold" [class.text-emerald-300]="openClawGatewayReachable()" [class.text-amber-300]="!openClawGatewayReachable()">{{ openClawGatewayReachable() ? 'OK' : 'WARN' }}</div>
+              <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ openClawSummary() }}</div>
+            } @else {
+              <div class="mt-3 text-3xl font-semibold text-[var(--cc-text-soft)]">—</div>
+              <div class="mt-2 text-sm text-[var(--cc-text-muted)]">runtime unavailable</div>
             }
           </button>
         </section>
@@ -346,6 +356,7 @@ export class HomePage {
   protected readonly notes = this.data.notes();
   protected readonly standup = this.data.standup();
   protected readonly infra = this.data.infra();
+  protected readonly openClaw = this.data.openClaw();
   protected readonly repos = this.data.repos();
   protected readonly refreshingAll = this.data.refreshingAll;
 
@@ -356,6 +367,14 @@ export class HomePage {
   protected readonly copiedPanel = signal<string | null>(null);
 
   protected readonly onlineServices = computed(() => (this.infra.data() ?? []).filter((process) => process.status === 'online').length);
+  protected readonly openClawGatewayReachable = computed(() => Boolean(this.openClaw.data()?.gateway?.reachable));
+  protected readonly openClawSummary = computed(() => {
+    const data = this.openClaw.data();
+    if (!data) return 'runtime unavailable';
+    const service = data.gatewayService?.runtime?.status || 'unknown service';
+    const sessions = data.agents?.totalSessions || 0;
+    return `${service} · ${sessions} sessions`;
+  });
   protected readonly upcomingEvents = computed(() => {
     return (this.calendar.data() ?? [])
       .filter((event) => new Date(event.start) > new Date())

--- a/frontend/src/app/features/openclaw/openclaw.page.ts
+++ b/frontend/src/app/features/openclaw/openclaw.page.ts
@@ -1,0 +1,218 @@
+import { Component, computed, inject } from '@angular/core';
+
+import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import { ViewShellComponent } from '../../layout/view-shell.component';
+import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
+import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
+import { PillComponent } from '../../shared/ui/pill.component';
+import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+
+@Component({
+  selector: 'app-openclaw-page',
+  imports: [ViewShellComponent, PanelActionsComponent, PillComponent, StatePanelComponent],
+  template: `
+    <app-view-shell eyebrow="OpenClaw" title="OpenClaw Runtime" subtitle="Gateway reachability, service state, agents, and the local runtime posture without leaving command-center." [meta]="meta()">
+      <div view-actions class="flex flex-wrap items-center gap-3">
+        <cc-panel-actions [actions]="headerActions" (actionSelected)="onHeaderAction($event)"></cc-panel-actions>
+      </div>
+
+      @if (openClaw.isLoading()) {
+        <cc-state-panel kind="loading" title="Loading OpenClaw runtime" message="Running local OpenClaw status checks for the dashboard."></cc-state-panel>
+      } @else if (openClaw.isUnavailable()) {
+        <cc-state-panel kind="unavailable" title="OpenClaw runtime unavailable" [message]="openClaw.error() || 'The local OpenClaw status command failed.'"></cc-state-panel>
+      } @else if (!openClaw.data()) {
+        <cc-state-panel kind="empty" title="No OpenClaw runtime data" message="No OpenClaw status payload was returned."></cc-state-panel>
+      } @else {
+        <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Gateway</div>
+              <cc-pill [tone]="gatewayTone()">{{ gatewayLabel() }}</cc-pill>
+            </div>
+            <div class="mt-4 text-2xl font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.gateway?.mode || 'unknown' }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ openClaw.data()!.gateway?.url || 'No gateway URL reported' }}</div>
+            <div class="mt-4 text-xs text-[var(--cc-text-soft)]">
+              @if (openClaw.data()!.gateway?.connectLatencyMs != null) {
+                {{ openClaw.data()!.gateway?.connectLatencyMs }} ms probe latency
+              } @else {
+                probe latency unavailable
+              }
+            </div>
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Gateway service</div>
+              <cc-pill [tone]="serviceTone(openClaw.data()!.gatewayService?.runtime?.status)">{{ openClaw.data()!.gatewayService?.runtime?.status || 'unknown' }}</cc-pill>
+            </div>
+            <div class="mt-4 text-2xl font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.gatewayService?.label || 'service' }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ openClaw.data()!.gatewayService?.runtimeShort || 'No runtime summary reported' }}</div>
+            <div class="mt-4 text-xs text-[var(--cc-text-soft)]">{{ openClaw.data()!.gatewayService?.loadedText || 'unknown load state' }}</div>
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Agents</div>
+              <cc-pill tone="info">{{ openClaw.data()!.agents?.agents?.length || 0 }} configured</cc-pill>
+            </div>
+            <div class="mt-4 text-2xl font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.agents?.totalSessions || 0 }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">recorded sessions</div>
+            <div class="mt-4 text-xs text-[var(--cc-text-soft)]">Default agent: {{ openClaw.data()!.agents?.defaultId || '—' }}</div>
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Runtime</div>
+              <cc-pill [tone]="openClaw.data()!.memoryPlugin?.enabled ? 'success' : 'warning'">{{ openClaw.data()!.memoryPlugin?.enabled ? 'memory on' : 'memory off' }}</cc-pill>
+            </div>
+            <div class="mt-4 text-2xl font-semibold text-[var(--cc-text)]">{{ currentVersion() }}</div>
+            <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ openClaw.data()!.gateway?.self?.host || 'unknown host' }} · {{ openClaw.data()!.gateway?.self?.ip || 'unknown ip' }}</div>
+            <div class="mt-4 text-xs text-[var(--cc-text-soft)]">{{ openClaw.data()!.gateway?.self?.platform || 'platform unavailable' }}</div>
+          </article>
+        </section>
+
+        <section class="grid gap-4 xl:grid-cols-[1.3fr_0.7fr]">
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Service details</div>
+                <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Gateway and node services</div>
+              </div>
+              @if (showUpdateBadge()) {
+                <cc-pill tone="warning">Update {{ latestVersion() }}</cc-pill>
+              }
+            </div>
+
+            <div class="mt-5 grid gap-4 lg:grid-cols-2">
+              <div class="cc-stat-surface p-4">
+                <div class="flex items-center justify-between gap-3">
+                  <div class="text-sm font-semibold text-[var(--cc-text)]">Gateway service</div>
+                  <cc-pill [tone]="serviceTone(openClaw.data()!.gatewayService?.runtime?.status)">{{ openClaw.data()!.gatewayService?.runtime?.status || 'unknown' }}</cc-pill>
+                </div>
+                <dl class="mt-4 space-y-2 text-sm text-[var(--cc-text-muted)]">
+                  <div class="flex items-center justify-between gap-4"><dt>Manager</dt><dd>{{ openClaw.data()!.gatewayService?.label || '—' }}</dd></div>
+                  <div class="flex items-center justify-between gap-4"><dt>Loaded</dt><dd>{{ openClaw.data()!.gatewayService?.loadedText || '—' }}</dd></div>
+                  <div class="flex items-center justify-between gap-4"><dt>PID</dt><dd>{{ openClaw.data()!.gatewayService?.runtime?.pid || '—' }}</dd></div>
+                  <div class="flex items-center justify-between gap-4"><dt>Last exit</dt><dd>{{ openClaw.data()!.gatewayService?.runtime?.lastExitStatus ?? '—' }}</dd></div>
+                </dl>
+              </div>
+
+              <div class="cc-stat-surface p-4">
+                <div class="flex items-center justify-between gap-3">
+                  <div class="text-sm font-semibold text-[var(--cc-text)]">Node service</div>
+                  <cc-pill [tone]="serviceTone(openClaw.data()!.nodeService?.runtime?.status)">{{ openClaw.data()!.nodeService?.runtime?.status || 'unknown' }}</cc-pill>
+                </div>
+                <dl class="mt-4 space-y-2 text-sm text-[var(--cc-text-muted)]">
+                  <div class="flex items-center justify-between gap-4"><dt>Installed</dt><dd>{{ openClaw.data()!.nodeService?.installed ? 'Yes' : 'No' }}</dd></div>
+                  <div class="flex items-center justify-between gap-4"><dt>Loaded</dt><dd>{{ openClaw.data()!.nodeService?.loadedText || '—' }}</dd></div>
+                  <div class="flex items-center justify-between gap-4"><dt>Status</dt><dd>{{ openClaw.data()!.nodeService?.runtimeShort || '—' }}</dd></div>
+                  <div class="flex items-center justify-between gap-4"><dt>Managed</dt><dd>{{ openClaw.data()!.nodeService?.managedByOpenClaw ? 'OpenClaw' : 'External / none' }}</dd></div>
+                </dl>
+              </div>
+            </div>
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Operator notes</div>
+            <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">At-a-glance posture</div>
+            <ul class="mt-5 space-y-3 text-sm text-[var(--cc-text-muted)]">
+              <li>Gateway is <span class="font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.gateway?.reachable ? 'reachable' : 'not reachable' }}</span>.</li>
+              <li>Memory plugin is <span class="font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.memoryPlugin?.enabled ? 'enabled' : 'disabled' }}</span>{{ openClaw.data()!.memoryPlugin?.slot ? ' via ' + openClaw.data()!.memoryPlugin?.slot : '' }}.</li>
+              <li>{{ openClaw.data()!.agents?.bootstrapPendingCount || 0 }} agents are waiting on bootstrap.</li>
+              <li>{{ secretStatus() }}</li>
+            </ul>
+          </article>
+        </section>
+
+        <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+          @for (agent of openClaw.data()!.agents?.agents || []; track agent.id) {
+            <article class="cc-list-card p-5">
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <div class="text-base font-semibold text-[var(--cc-text)]">{{ agent.name }}</div>
+                  <div class="mt-2 text-xs text-[var(--cc-text-soft)]">{{ agent.id }} · {{ agent.workspaceDir }}</div>
+                </div>
+                <cc-pill [tone]="agent.bootstrapPending ? 'warning' : 'success'">{{ agent.bootstrapPending ? 'bootstrap pending' : 'ready' }}</cc-pill>
+              </div>
+              <dl class="mt-4 space-y-2 text-sm text-[var(--cc-text-muted)]">
+                <div class="flex items-center justify-between gap-4"><dt>Sessions</dt><dd>{{ agent.sessionsCount }}</dd></div>
+                <div class="flex items-center justify-between gap-4"><dt>Last active</dt><dd>{{ formatAge(agent.lastActiveAgeMs) }}</dd></div>
+                <div class="flex items-center justify-between gap-4"><dt>Session index</dt><dd class="truncate text-right">{{ agent.sessionsPath }}</dd></div>
+              </dl>
+            </article>
+          }
+        </section>
+      }
+    </app-view-shell>
+  `,
+})
+export class OpenClawPage {
+  private readonly data = inject(DashboardDataService);
+
+  protected readonly openClaw = this.data.openClaw();
+  protected readonly headerActions = STANDARD_PANEL_ACTIONS;
+  protected readonly currentVersion = computed(() => this.openClaw.data()?.version || this.openClaw.data()?.gateway?.self?.version || 'unknown');
+  protected readonly latestVersion = computed(() => this.openClaw.data()?.updateInfo?.latestVersion || 'available');
+  protected readonly showUpdateBadge = computed(() => {
+    const latest = this.openClaw.data()?.updateInfo?.latestVersion;
+    const current = this.currentVersion();
+    return Boolean(latest && current && latest !== current);
+  });
+  protected readonly meta = computed(() => {
+    const gateway = this.openClaw.data()?.gateway?.reachable ? 'gateway reachable' : 'gateway down';
+    const service = this.openClaw.data()?.gatewayService?.runtime?.status || 'unknown service';
+    const sessions = this.openClaw.data()?.agents?.totalSessions || 0;
+    return `${gateway} · ${service} · ${sessions} sessions`;
+  });
+
+  protected onHeaderAction(actionId: string): void {
+    if (actionId === 'refresh') {
+      this.openClaw.refresh();
+      return;
+    }
+
+    if (actionId === 'copy') {
+      void this.copyLink();
+    }
+  }
+
+  protected gatewayTone(): 'success' | 'danger' | 'warning' {
+    const gateway = this.openClaw.data()?.gateway;
+    if (!gateway) return 'warning';
+    if (gateway.reachable) return 'success';
+    return gateway.misconfigured ? 'danger' : 'warning';
+  }
+
+  protected gatewayLabel(): string {
+    const gateway = this.openClaw.data()?.gateway;
+    if (!gateway) return 'unknown';
+    if (gateway.reachable) return 'reachable';
+    if (gateway.misconfigured) return 'misconfigured';
+    return 'offline';
+  }
+
+  protected serviceTone(status?: string | null): 'success' | 'danger' | 'warning' {
+    if (status === 'running') return 'success';
+    if (status === 'stopped') return 'warning';
+    if (status === 'failed') return 'danger';
+    return 'warning';
+  }
+
+  protected secretStatus(): string {
+    const count = this.openClaw.data()?.secretDiagnostics?.length || 0;
+    return count > 0 ? `${count} secret diagnostics need attention.` : 'No secret diagnostics are currently flagged.';
+  }
+
+  protected formatAge(ageMs?: number | null): string {
+    if (ageMs == null) return '—';
+    if (ageMs < 60_000) return `${Math.max(1, Math.round(ageMs / 1000))}s ago`;
+    if (ageMs < 3_600_000) return `${Math.round(ageMs / 60_000)}m ago`;
+    if (ageMs < 86_400_000) return `${Math.round(ageMs / 3_600_000)}h ago`;
+    return `${Math.round(ageMs / 86_400_000)}d ago`;
+  }
+
+  private async copyLink(): Promise<void> {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    await navigator.clipboard.writeText(window.location.href);
+  }
+}

--- a/frontend/src/app/features/openclaw/openclaw.page.ts
+++ b/frontend/src/app/features/openclaw/openclaw.page.ts
@@ -47,7 +47,9 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
             </div>
             <div class="mt-4 text-2xl font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.gatewayService?.label || 'service' }}</div>
             <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ openClaw.data()!.gatewayService?.runtimeShort || 'No runtime summary reported' }}</div>
-            <div class="mt-4 text-xs text-[var(--cc-text-soft)]">{{ openClaw.data()!.gatewayService?.loadedText || 'unknown load state' }}</div>
+            <div class="mt-4 text-xs text-[var(--cc-text-soft)]">
+              {{ openClaw.data()!.gatewayProcess?.elapsed || 'uptime unavailable' }} · {{ formatMemory(openClaw.data()!.gatewayProcess?.memoryBytes) }}
+            </div>
           </article>
 
           <article class="cc-list-card p-5">
@@ -119,8 +121,32 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
               <li>Gateway is <span class="font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.gateway?.reachable ? 'reachable' : 'not reachable' }}</span>.</li>
               <li>Memory plugin is <span class="font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.memoryPlugin?.enabled ? 'enabled' : 'disabled' }}</span>{{ openClaw.data()!.memoryPlugin?.slot ? ' via ' + openClaw.data()!.memoryPlugin?.slot : '' }}.</li>
               <li>{{ openClaw.data()!.agents?.bootstrapPendingCount || 0 }} agents are waiting on bootstrap.</li>
+              <li>{{ taskStatus() }}</li>
               <li>{{ secretStatus() }}</li>
             </ul>
+          </article>
+        </section>
+
+        <section class="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+          <article class="cc-list-card p-5">
+            <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Channel summary</div>
+            <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Configured surfaces</div>
+            <div class="mt-5 space-y-3">
+              @for (line of openClaw.data()!.channelSummary || []; track line) {
+                <div class="cc-stat-surface p-4 text-sm text-[var(--cc-text-muted)]">{{ line }}</div>
+              }
+            </div>
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Task health</div>
+            <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Recent runtime jobs</div>
+            <div class="mt-5 grid grid-cols-2 gap-4">
+              <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Total</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.tasks?.total || 0 }}</div></div>
+              <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Failures</div><div class="mt-2 text-2xl font-semibold text-rose-300">{{ openClaw.data()!.tasks?.failures || 0 }}</div></div>
+              <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Warnings</div><div class="mt-2 text-2xl font-semibold text-amber-300">{{ openClaw.data()!.taskAudit?.warnings || 0 }}</div></div>
+              <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Errors</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.taskAudit?.errors || 0 }}</div></div>
+            </div>
           </article>
         </section>
 
@@ -198,6 +224,15 @@ export class OpenClawPage {
     return 'warning';
   }
 
+  protected taskStatus(): string {
+    const failures = this.openClaw.data()?.tasks?.failures || 0;
+    const warnings = this.openClaw.data()?.taskAudit?.warnings || 0;
+    if (!failures && !warnings) return 'Recent runtime jobs look clean.';
+    if (failures && warnings) return `${failures} runtime job failures and ${warnings} audit warnings are currently reported.`;
+    if (failures) return `${failures} runtime job failures are currently reported.`;
+    return `${warnings} runtime audit warnings are currently reported.`;
+  }
+
   protected secretStatus(): string {
     const count = this.openClaw.data()?.secretDiagnostics?.length || 0;
     return count > 0 ? `${count} secret diagnostics need attention.` : 'No secret diagnostics are currently flagged.';
@@ -209,6 +244,11 @@ export class OpenClawPage {
     if (ageMs < 3_600_000) return `${Math.round(ageMs / 60_000)}m ago`;
     if (ageMs < 86_400_000) return `${Math.round(ageMs / 3_600_000)}h ago`;
     return `${Math.round(ageMs / 86_400_000)}d ago`;
+  }
+
+  protected formatMemory(bytes?: number | null): string {
+    if (!bytes) return 'memory unavailable';
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB RSS`;
   }
 
   private async copyLink(): Promise<void> {

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -280,13 +280,40 @@ export interface OpenClawMemoryPlugin {
   slot?: string | null;
 }
 
+export interface OpenClawProcessSnapshot {
+  elapsed: string;
+  memoryBytes: number | null;
+}
+
+export interface OpenClawTasksSummary {
+  total: number;
+  active: number;
+  terminal: number;
+  failures: number;
+  byStatus?: Record<string, number>;
+  byRuntime?: Record<string, number>;
+}
+
+export interface OpenClawTaskAudit {
+  total: number;
+  warnings: number;
+  errors: number;
+  byCode?: Record<string, number>;
+}
+
 export interface OpenClawResponse extends ApiEnvelope {
   version: string | null;
   gateway: OpenClawGateway | null;
   gatewayService: OpenClawServiceStatus | null;
+  gatewayProcess?: OpenClawProcessSnapshot | null;
   nodeService: OpenClawServiceStatus | null;
   agents: OpenClawAgentsSummary | null;
+  sessions?: unknown;
+  memory?: unknown;
   memoryPlugin: OpenClawMemoryPlugin | null;
+  tasks?: OpenClawTasksSummary | null;
+  taskAudit?: OpenClawTaskAudit | null;
+  channelSummary?: string[];
   updateAvailable?: boolean | null;
   updateChannel?: string | null;
   updateInfo?: { latestVersion?: string | null } | null;

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -218,6 +218,82 @@ export interface NotesResponse extends ApiEnvelope {
   decisions: DecisionNote[];
 }
 
+export interface OpenClawGatewaySelf {
+  host: string;
+  ip: string;
+  version: string;
+  platform: string;
+}
+
+export interface OpenClawGateway {
+  mode: string;
+  url: string;
+  urlSource?: string | null;
+  misconfigured: boolean;
+  reachable: boolean;
+  connectLatencyMs?: number | null;
+  self?: OpenClawGatewaySelf | null;
+  error?: string | null;
+  authWarning?: string | null;
+}
+
+export interface OpenClawServiceRuntime {
+  status: string;
+  state: string;
+  subState?: string | null;
+  pid?: number | null;
+  lastExitStatus?: number | null;
+  lastExitReason?: string | null;
+}
+
+export interface OpenClawServiceStatus {
+  label: string;
+  installed: boolean;
+  loaded: boolean;
+  managedByOpenClaw: boolean;
+  externallyManaged: boolean;
+  loadedText?: string | null;
+  runtime?: OpenClawServiceRuntime | null;
+  runtimeShort?: string | null;
+}
+
+export interface OpenClawAgentStatus {
+  id: string;
+  name: string;
+  workspaceDir: string;
+  bootstrapPending: boolean;
+  sessionsPath: string;
+  sessionsCount: number;
+  lastUpdatedAt?: number | null;
+  lastActiveAgeMs?: number | null;
+}
+
+export interface OpenClawAgentsSummary {
+  defaultId?: string | null;
+  agents: OpenClawAgentStatus[];
+  totalSessions: number;
+  bootstrapPendingCount: number;
+}
+
+export interface OpenClawMemoryPlugin {
+  enabled: boolean;
+  slot?: string | null;
+}
+
+export interface OpenClawResponse extends ApiEnvelope {
+  version: string | null;
+  gateway: OpenClawGateway | null;
+  gatewayService: OpenClawServiceStatus | null;
+  nodeService: OpenClawServiceStatus | null;
+  agents: OpenClawAgentsSummary | null;
+  memoryPlugin: OpenClawMemoryPlugin | null;
+  updateAvailable?: boolean | null;
+  updateChannel?: string | null;
+  updateInfo?: { latestVersion?: string | null } | null;
+  secretDiagnostics: unknown[];
+  updatedAt: number | null;
+}
+
 export interface RefreshResponse {
   ok: boolean;
 }

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -17,6 +17,7 @@ function createApp(options) {
     fetchStandup,
     fetchPRs,
     fetchAnalytics,
+    fetchOpenClawRuntime,
     closeIssue,
     loadInfraProcesses,
     frontend,
@@ -104,6 +105,16 @@ function createApp(options) {
       return res.status(sourceResponseStatus(source)).json({ ok: false, error: source.error || source.status, source });
     }
     return res.json({ ok: true, ...cache.notes, source });
+  });
+
+  app.get('/api/openclaw', (req, res) => {
+    try {
+      const runtime = fetchOpenClawRuntime();
+      return res.json({ ok: true, ...runtime, source: sourceMeta('openclaw') });
+    } catch (error) {
+      const source = sourceMeta('openclaw');
+      return res.status(sourceResponseStatus(source)).json({ ok: false, error: error.message, source });
+    }
   });
 
   app.post('/api/issues/:owner/:repo/:number/close', async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -610,6 +610,27 @@ function loadInfraProcesses() {
   }));
 }
 
+function readProcessSnapshot(pid) {
+  if (!pid) return null;
+
+  try {
+    const raw = execFileSync('ps', ['-p', String(pid), '-o', 'etime=,rss='], {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+
+    if (!raw) return null;
+
+    const [elapsed, rssKb] = raw.split(/\s+/, 2);
+    return {
+      elapsed,
+      memoryBytes: rssKb ? Number(rssKb) * 1024 : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function fetchOpenClawRuntime() {
   beginSource('openclaw');
   try {
@@ -620,17 +641,26 @@ function fetchOpenClawRuntime() {
     });
     const status = JSON.parse(raw);
     const updatedAt = Date.now();
+    const gatewayPid = status.gatewayService?.runtime?.pid;
+    const gatewayProcess = readProcessSnapshot(gatewayPid);
+
     succeedSource('openclaw', updatedAt);
     return {
-      version: status.gateway?.self?.version || null,
+      version: status.runtimeVersion || status.gateway?.self?.version || null,
       gateway: status.gateway || null,
       gatewayService: status.gatewayService || null,
+      gatewayProcess,
       nodeService: status.nodeService || null,
       agents: status.agents || null,
+      sessions: status.sessions || null,
+      memory: status.memory || null,
       memoryPlugin: status.memoryPlugin || null,
-      updateAvailable: status.updateAvailable || null,
+      tasks: status.tasks || null,
+      taskAudit: status.taskAudit || null,
+      channelSummary: status.channelSummary || [],
+      updateAvailable: status.update?.registry?.latestVersion ? status.update.registry.latestVersion !== (status.runtimeVersion || status.gateway?.self?.version || null) : null,
       updateChannel: status.updateChannel || null,
-      updateInfo: status.doctor?.registry || null,
+      updateInfo: status.update?.registry || null,
       secretDiagnostics: status.secretDiagnostics || [],
       updatedAt,
     };

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@
 
 require('dotenv').config();
 
-const { execSync } = require('child_process');
+const { execFileSync, execSync } = require('child_process');
 const path = require('path');
 const cron = require('node-cron');
 const ical = require('node-ical');
@@ -111,6 +111,7 @@ const SOURCE_CONFIG = {
   prs: { label: 'PRs', staleAfterMs: 15 * 60 * 1000 },
   analytics: { label: 'Analytics', staleAfterMs: 30 * 60 * 1000 },
   infra: { label: 'Infra', staleAfterMs: 5 * 60 * 1000 },
+  openclaw: { label: 'OpenClaw', staleAfterMs: 2 * 60 * 1000 },
 };
 
 let sourceState = Object.fromEntries(
@@ -609,6 +610,36 @@ function loadInfraProcesses() {
   }));
 }
 
+function fetchOpenClawRuntime() {
+  beginSource('openclaw');
+  try {
+    const raw = execFileSync('openclaw', ['status', '--json'], {
+      encoding: 'utf8',
+      timeout: 15000,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    const status = JSON.parse(raw);
+    const updatedAt = Date.now();
+    succeedSource('openclaw', updatedAt);
+    return {
+      version: status.gateway?.self?.version || null,
+      gateway: status.gateway || null,
+      gatewayService: status.gatewayService || null,
+      nodeService: status.nodeService || null,
+      agents: status.agents || null,
+      memoryPlugin: status.memoryPlugin || null,
+      updateAvailable: status.updateAvailable || null,
+      updateChannel: status.updateChannel || null,
+      updateInfo: status.doctor?.registry || null,
+      secretDiagnostics: status.secretDiagnostics || [],
+      updatedAt,
+    };
+  } catch (error) {
+    failSource('openclaw', error);
+    throw error;
+  }
+}
+
 const app = createApp({
   cache,
   sourceMeta,
@@ -623,6 +654,7 @@ const app = createApp({
   fetchStandup,
   fetchPRs,
   fetchAnalytics,
+  fetchOpenClawRuntime,
   closeIssue: ({ owner, repo, number }) => execSync(`gh issue close ${number} --repo ${owner}/${repo}`, { encoding: 'utf8' }),
   loadInfraProcesses,
   frontend: {
@@ -661,4 +693,5 @@ module.exports = {
   sourceMeta,
   sourceResponseStatus,
   loadInfraProcesses,
+  fetchOpenClawRuntime,
 };

--- a/test/api-smoke.test.js
+++ b/test/api-smoke.test.js
@@ -69,6 +69,19 @@ function createTestApp({ cacheOverrides = {}, sourceOverrides = {}, infraError =
     fetchStandup: () => refreshCalls.push('standup'),
     fetchPRs: () => refreshCalls.push('prs'),
     fetchAnalytics: () => refreshCalls.push('analytics'),
+    fetchOpenClawRuntime: () => ({
+      version: '2026.4.12',
+      gateway: { mode: 'local', url: 'ws://127.0.0.1:39217', reachable: true, misconfigured: false },
+      gatewayService: { label: 'systemd', runtime: { status: 'running', state: 'active', pid: 2542 }, runtimeShort: 'running (pid 2542, state active)' },
+      nodeService: { label: 'systemd', installed: false, loaded: false, managedByOpenClaw: false, externallyManaged: false, runtime: { status: 'stopped', state: 'inactive' }, runtimeShort: 'stopped (state inactive)' },
+      agents: { defaultId: 'main', agents: [{ id: 'main', name: 'main', workspaceDir: '/tmp/workspace', bootstrapPending: false, sessionsPath: '/tmp/sessions.json', sessionsCount: 16 }], totalSessions: 16, bootstrapPendingCount: 0 },
+      memoryPlugin: { enabled: true, slot: 'memory-core' },
+      updateAvailable: false,
+      updateChannel: 'stable',
+      updateInfo: { latestVersion: '2026.4.14' },
+      secretDiagnostics: [],
+      updatedAt: 1713124800000,
+    }),
     closeIssue: async () => refreshCalls.push('closeIssue'),
     loadInfraProcesses: () => {
       if (infraError) throw infraError;
@@ -128,6 +141,11 @@ test('main API routes return smoke-level shapes', async () => {
       const analytics = await fetch(`${baseUrl}/api/analytics`).then(res => res.json());
       assert.equal(analytics.ok, true);
       assert.equal(analytics.totals.pageviews, 42);
+
+      const openClaw = await fetch(`${baseUrl}/api/openclaw`).then(res => res.json());
+      assert.equal(openClaw.ok, true);
+      assert.equal(openClaw.gateway.reachable, true);
+      assert.equal(openClaw.agents.totalSessions, 16);
     });
   } finally {
     cleanup();


### PR DESCRIPTION
## Summary
- add a backend /api/openclaw route backed by real `openclaw status --json` data
- add an Angular OpenClaw Runtime view plus a Home summary card
- surface gateway health, service state, version, uptime, memory, agents, task failures, channel summary, and update/secret diagnostics

## Testing
- npm test
- npm --prefix frontend run build
- ephemeral local sanity check for /api/openclaw and /openclaw

Closes #50