### PR TITLE
Add OpenClaw active sessions and recent run activity

### DIFF
--- a/frontend/src/app/core/data/dashboard-data.service.ts
+++ b/frontend/src/app/core/data/dashboard-data.service.ts
@@ -46,6 +46,8 @@ export class DashboardDataService {
     tasks: OpenClawResponse['tasks'];
     taskAudit: OpenClawResponse['taskAudit'];
     channelSummary: OpenClawResponse['channelSummary'];
+    activeSessions: OpenClawResponse['activeSessions'];
+    recentRuns: OpenClawResponse['recentRuns'];
     updateAvailable: OpenClawResponse['updateAvailable'];
     updateChannel: OpenClawResponse['updateChannel'];
     updateInfo: OpenClawResponse['updateInfo'];
@@ -159,6 +161,8 @@ export class DashboardDataService {
     tasks: OpenClawResponse['tasks'];
     taskAudit: OpenClawResponse['taskAudit'];
     channelSummary: OpenClawResponse['channelSummary'];
+    activeSessions: OpenClawResponse['activeSessions'];
+    recentRuns: OpenClawResponse['recentRuns'];
     updateAvailable: OpenClawResponse['updateAvailable'];
     updateChannel: OpenClawResponse['updateChannel'];
     updateInfo: OpenClawResponse['updateInfo'];
@@ -180,6 +184,8 @@ export class DashboardDataService {
         tasks: response.tasks,
         taskAudit: response.taskAudit,
         channelSummary: response.channelSummary,
+        activeSessions: response.activeSessions,
+        recentRuns: response.recentRuns,
         updateAvailable: response.updateAvailable,
         updateChannel: response.updateChannel,
         updateInfo: response.updateInfo,

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -372,8 +372,8 @@ export class HomePage {
     const data = this.openClaw.data();
     if (!data) return 'runtime unavailable';
     const service = data.gatewayService?.runtime?.status || 'unknown service';
-    const sessions = data.agents?.totalSessions || 0;
-    return `${service} · ${sessions} sessions`;
+    const liveSessions = (data.activeSessions ?? []).filter((session) => session.active).length;
+    return `${service} · ${liveSessions} live sessions`;
   });
   protected readonly upcomingEvents = computed(() => {
     return (this.calendar.data() ?? [])

--- a/frontend/src/app/features/openclaw/openclaw.page.ts
+++ b/frontend/src/app/features/openclaw/openclaw.page.ts
@@ -150,6 +150,82 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           </article>
         </section>
 
+        <section class="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Active sessions</div>
+                <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">What Atlas is doing right now</div>
+              </div>
+              <cc-pill tone="info">{{ activeSessionCount() }} live</cc-pill>
+            </div>
+
+            @if (!openClaw.data()!.activeSessions.length) {
+              <cc-state-panel class="mt-5" kind="empty" title="No recent sessions" message="No OpenClaw sessions were active in the recent window."></cc-state-panel>
+            } @else {
+              <div class="mt-5 space-y-3">
+                @for (session of openClaw.data()!.activeSessions; track session.key) {
+                  <div class="cc-stat-surface p-4">
+                    <div class="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div class="text-sm font-semibold text-[var(--cc-text)]">{{ session.name }}</div>
+                        <div class="mt-2 text-xs text-[var(--cc-text-soft)]">{{ session.agent }} · {{ session.model }}</div>
+                      </div>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <cc-pill [tone]="session.active ? 'success' : 'warning'">{{ session.active ? 'active' : 'idle' }}</cc-pill>
+                        <cc-pill [tone]="sessionTypeTone(session.type)">{{ session.type }}</cc-pill>
+                      </div>
+                    </div>
+                    <dl class="mt-4 grid gap-3 text-sm text-[var(--cc-text-muted)] md:grid-cols-4">
+                      <div><dt class="text-[var(--cc-text-soft)]">Last seen</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatAge(session.ageMs) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Context</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ session.percentUsed == null ? '—' : session.percentUsed + '%' }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Tokens</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ session.totalTokens }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Trigger</dt><dd class="mt-1 truncate font-medium text-[var(--cc-text)]">{{ session.subject || session.label || '—' }}</dd></div>
+                    </dl>
+                  </div>
+                }
+              </div>
+            }
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Recent activity</div>
+                <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Recent runs and spawned work</div>
+              </div>
+              <cc-pill tone="info">{{ openClaw.data()!.recentRuns.length }}</cc-pill>
+            </div>
+
+            @if (!openClaw.data()!.recentRuns.length) {
+              <cc-state-panel class="mt-5" kind="empty" title="No recent spawned work" message="Sub-agent and run activity will show up here once OpenClaw records it."></cc-state-panel>
+            } @else {
+              <div class="mt-5 space-y-3">
+                @for (run of openClaw.data()!.recentRuns; track run.key) {
+                  <div class="cc-stat-surface p-4">
+                    <div class="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div class="text-sm font-semibold text-[var(--cc-text)]">{{ run.name }}</div>
+                        <div class="mt-2 text-xs text-[var(--cc-text-soft)]">{{ run.agent }} · {{ run.model }}</div>
+                      </div>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <cc-pill [tone]="runStatusTone(run.status)">{{ run.status }}</cc-pill>
+                        <cc-pill [tone]="sessionTypeTone(run.type)">{{ run.type }}</cc-pill>
+                      </div>
+                    </div>
+                    <dl class="mt-4 grid gap-3 text-sm text-[var(--cc-text-muted)] md:grid-cols-4">
+                      <div><dt class="text-[var(--cc-text-soft)]">Finished</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatAge(run.ageMs) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Duration</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatDuration(run.durationSec) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Tokens</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ run.totalTokens }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Cost</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatCost(run.estimatedCostUsd) }}</dd></div>
+                    </dl>
+                  </div>
+                }
+              </div>
+            }
+          </article>
+        </section>
+
         <section class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
           @for (agent of openClaw.data()!.agents?.agents || []; track agent.id) {
             <article class="cc-list-card p-5">
@@ -184,11 +260,12 @@ export class OpenClawPage {
     const current = this.currentVersion();
     return Boolean(latest && current && latest !== current);
   });
+  protected readonly activeSessionCount = computed(() => (this.openClaw.data()?.activeSessions ?? []).filter((session) => session.active).length);
   protected readonly meta = computed(() => {
     const gateway = this.openClaw.data()?.gateway?.reachable ? 'gateway reachable' : 'gateway down';
     const service = this.openClaw.data()?.gatewayService?.runtime?.status || 'unknown service';
-    const sessions = this.openClaw.data()?.agents?.totalSessions || 0;
-    return `${gateway} · ${service} · ${sessions} sessions`;
+    const sessions = this.activeSessionCount();
+    return `${gateway} · ${service} · ${sessions} live sessions`;
   });
 
   protected onHeaderAction(actionId: string): void {
@@ -224,6 +301,20 @@ export class OpenClawPage {
     return 'warning';
   }
 
+  protected sessionTypeTone(type?: string | null): 'success' | 'danger' | 'warning' | 'info' {
+    if (type === 'subagent' || type === 'run') return 'info';
+    if (type === 'group') return 'warning';
+    if (type === 'cron') return 'danger';
+    return 'success';
+  }
+
+  protected runStatusTone(status?: string | null): 'success' | 'danger' | 'warning' | 'info' {
+    if (status === 'completed') return 'success';
+    if (status === 'aborted') return 'danger';
+    if (status === 'active') return 'info';
+    return 'warning';
+  }
+
   protected taskStatus(): string {
     const failures = this.openClaw.data()?.tasks?.failures || 0;
     const warnings = this.openClaw.data()?.taskAudit?.warnings || 0;
@@ -249,6 +340,21 @@ export class OpenClawPage {
   protected formatMemory(bytes?: number | null): string {
     if (!bytes) return 'memory unavailable';
     return `${(bytes / 1024 / 1024).toFixed(1)} MB RSS`;
+  }
+
+  protected formatDuration(seconds?: number | null): string {
+    if (seconds == null) return '—';
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ${minutes % 60}m`;
+  }
+
+  protected formatCost(value?: number | null): string {
+    if (value == null) return '—';
+    return `$${value.toFixed(4)}`;
   }
 
   private async copyLink(): Promise<void> {

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -301,6 +301,32 @@ export interface OpenClawTaskAudit {
   byCode?: Record<string, number>;
 }
 
+export interface OpenClawSessionSummary {
+  key: string;
+  sessionId: string;
+  agent: string;
+  type: string;
+  name: string;
+  model: string;
+  updatedAt: number;
+  ageMs: number;
+  active: boolean;
+  percentUsed: number | null;
+  totalTokens: number;
+  contextTokens: number | null;
+  estimatedCostUsd: number | null;
+  chatType?: string | null;
+  label?: string | null;
+  subject?: string | null;
+  spawnedBy?: string | null;
+  abortedLastRun: boolean;
+}
+
+export interface OpenClawRunSummary extends OpenClawSessionSummary {
+  durationSec: number | null;
+  status: string;
+}
+
 export interface OpenClawResponse extends ApiEnvelope {
   version: string | null;
   gateway: OpenClawGateway | null;
@@ -314,6 +340,8 @@ export interface OpenClawResponse extends ApiEnvelope {
   tasks?: OpenClawTasksSummary | null;
   taskAudit?: OpenClawTaskAudit | null;
   channelSummary?: string[];
+  activeSessions: OpenClawSessionSummary[];
+  recentRuns: OpenClawRunSummary[];
   updateAvailable?: boolean | null;
   updateChannel?: string | null;
   updateInfo?: { latestVersion?: string | null } | null;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,6 +12,8 @@
   --cc-surface-muted: rgba(30, 41, 59, 0.72);
   --cc-surface-soft: rgba(15, 23, 42, 0.58);
   --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(56, 189, 248, 0.14));
+  --cc-table-surface: rgba(15, 23, 42, 0.65);
+  --cc-table-shadow: 0 30px 90px -48px rgba(15, 23, 42, 1);
   --cc-border: rgba(148, 163, 184, 0.16);
   --cc-border-strong: rgba(255, 255, 255, 0.16);
   --cc-text: #e5edf8;
@@ -32,6 +34,8 @@ html.light {
   --cc-surface-muted: rgba(248, 250, 252, 0.92);
   --cc-surface-soft: rgba(255, 255, 255, 0.66);
   --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(56, 189, 248, 0.09));
+  --cc-table-surface: rgba(255, 255, 255, 0.82);
+  --cc-table-shadow: 0 30px 90px -48px rgba(15, 23, 42, 0.16);
   --cc-border: rgba(15, 23, 42, 0.08);
   --cc-border-strong: rgba(15, 23, 42, 0.12);
   --cc-text: #0f172a;
@@ -265,9 +269,9 @@ code {
 .cc-table-shell {
   overflow: hidden;
   border-radius: 1.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 23, 42, 0.65);
-  box-shadow: 0 30px 90px -48px rgba(15, 23, 42, 1);
+  border: 1px solid var(--cc-border);
+  background: var(--cc-table-surface);
+  box-shadow: var(--cc-table-shadow);
   backdrop-filter: blur(24px);
 }
 

--- a/server.js
+++ b/server.js
@@ -631,6 +631,160 @@ function readProcessSnapshot(pid) {
   }
 }
 
+const OPENCLAW_AGENTS_DIR = path.join(process.env.HOME || '', '.openclaw', 'agents');
+const OPENCLAW_ACTIVE_WINDOW_MS = 30 * 60 * 1000;
+const OPENCLAW_RECENT_SESSION_MS = 24 * 60 * 60 * 1000;
+const OPENCLAW_RECENT_ACTIVITY_MS = 7 * 24 * 60 * 60 * 1000;
+
+function readJsonFileSafe(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function openClawSessionType(key, entry = {}) {
+  if (key.includes(':run:')) return 'run';
+  if (key.includes('subagent:')) return 'subagent';
+  if (key.includes('cron:')) return 'cron';
+  if (key.includes(':channel:') || entry.chatType === 'group') return 'group';
+  if (key.includes(':direct:') || entry.chatType === 'direct') return 'direct';
+  if (key.endsWith(':main')) return 'main';
+  return entry.chatType || 'other';
+}
+
+function openClawSessionName(key, entry = {}) {
+  if (entry.label) return String(entry.label).slice(0, 80);
+  if (entry.subject) return String(entry.subject).slice(0, 80);
+  if (key.endsWith(':main')) return 'Main session';
+  if (key.includes(':discord:direct:')) return `Discord DM · ${key.split(':').at(-1)}`;
+  if (key.includes(':discord:channel:')) return `Discord channel · ${key.split(':').at(-1)}`;
+  const originLabel = entry.origin?.label;
+  const raw = originLabel || key;
+  return String(raw).replace(/^agent:[^:]+:/, '').slice(0, 80);
+}
+
+function openClawSessionModel(entry = {}) {
+  if (entry.providerOverride && entry.modelOverride) return `${entry.providerOverride}/${entry.modelOverride}`;
+  if (entry.modelProvider && entry.model && typeof entry.model === 'string' && !entry.model.includes('/')) return `${entry.modelProvider}/${entry.model}`;
+  return entry.model || 'unknown';
+}
+
+function openClawSessionPercentUsed(entry = {}) {
+  const totalTokens = Number(entry.totalTokens || 0);
+  const contextTokens = Number(entry.contextTokens || 0);
+  if (!totalTokens || !contextTokens) return null;
+  return Math.min(100, Math.round((totalTokens / contextTokens) * 1000) / 10);
+}
+
+function readSessionDurationSec(sessionFile, entry = {}) {
+  const runtimeMs = Number(entry.runtimeMs || 0);
+  if (runtimeMs > 0) return Math.round(runtimeMs / 1000);
+
+  const startedAt = Number(entry.startedAt || 0);
+  const endedAt = Number(entry.endedAt || 0);
+  if (startedAt > 0 && endedAt >= startedAt) {
+    return Math.round((endedAt - startedAt) / 1000);
+  }
+
+  if (!sessionFile || !fs.existsSync(sessionFile) || sessionFile.endsWith('.lock')) return null;
+
+  try {
+    const lines = fs.readFileSync(sessionFile, 'utf8').split('\n').filter(Boolean);
+    let first = null;
+    let last = null;
+
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line);
+        if (!parsed?.timestamp) continue;
+        const ts = Date.parse(parsed.timestamp);
+        if (Number.isNaN(ts)) continue;
+        if (first === null) first = ts;
+        last = ts;
+      } catch {
+        // ignore malformed lines
+      }
+    }
+
+    if (first === null || last === null || last < first) return null;
+    return Math.max(0, Math.round((last - first) / 1000));
+  } catch {
+    return null;
+  }
+}
+
+function collectOpenClawActivity() {
+  const activeSessions = [];
+  const recentRuns = [];
+  const now = Date.now();
+
+  if (!OPENCLAW_AGENTS_DIR || !fs.existsSync(OPENCLAW_AGENTS_DIR)) {
+    return { activeSessions, recentRuns };
+  }
+
+  for (const agentName of fs.readdirSync(OPENCLAW_AGENTS_DIR)) {
+    const sessionsDir = path.join(OPENCLAW_AGENTS_DIR, agentName, 'sessions');
+    const storePath = path.join(sessionsDir, 'sessions.json');
+    if (!fs.existsSync(storePath)) continue;
+
+    let store;
+    try {
+      store = readJsonFileSafe(storePath);
+    } catch {
+      continue;
+    }
+
+    for (const [key, rawEntry] of Object.entries(store)) {
+      const entry = rawEntry || {};
+      const sessionId = entry.sessionId;
+      const updatedAt = Number(entry.updatedAt || 0);
+      if (!sessionId || !updatedAt) continue;
+
+      const type = openClawSessionType(key, entry);
+      const ageMs = Math.max(0, now - updatedAt);
+      const sessionFile = entry.sessionFile || path.join(sessionsDir, `${sessionId}.jsonl`);
+      const sessionSummary = {
+        key,
+        sessionId,
+        agent: agentName,
+        type,
+        name: openClawSessionName(key, entry),
+        model: openClawSessionModel(entry),
+        updatedAt,
+        ageMs,
+        active: ageMs <= OPENCLAW_ACTIVE_WINDOW_MS,
+        percentUsed: openClawSessionPercentUsed(entry),
+        totalTokens: Number(entry.totalTokens || 0),
+        contextTokens: Number(entry.contextTokens || 0) || null,
+        estimatedCostUsd: entry.estimatedCostUsd ?? null,
+        chatType: entry.chatType || null,
+        label: entry.label || null,
+        subject: entry.subject || null,
+        spawnedBy: entry.spawnedBy || null,
+        abortedLastRun: Boolean(entry.abortedLastRun),
+      };
+
+      if (!key.includes(':run:') && ageMs <= OPENCLAW_RECENT_SESSION_MS) {
+        activeSessions.push(sessionSummary);
+      }
+
+      if ((key.includes(':run:') || type === 'subagent') && ageMs <= OPENCLAW_RECENT_ACTIVITY_MS) {
+        recentRuns.push({
+          ...sessionSummary,
+          durationSec: readSessionDurationSec(sessionFile, entry),
+          status: sessionSummary.abortedLastRun ? 'aborted' : sessionSummary.active ? 'active' : 'completed',
+        });
+      }
+    }
+  }
+
+  activeSessions.sort((a, b) => b.updatedAt - a.updatedAt);
+  recentRuns.sort((a, b) => b.updatedAt - a.updatedAt);
+
+  return {
+    activeSessions: activeSessions.slice(0, 20),
+    recentRuns: recentRuns.slice(0, 20),
+  };
+}
+
 function fetchOpenClawRuntime() {
   beginSource('openclaw');
   try {
@@ -643,6 +797,7 @@ function fetchOpenClawRuntime() {
     const updatedAt = Date.now();
     const gatewayPid = status.gatewayService?.runtime?.pid;
     const gatewayProcess = readProcessSnapshot(gatewayPid);
+    const activity = collectOpenClawActivity();
 
     succeedSource('openclaw', updatedAt);
     return {
@@ -662,6 +817,8 @@ function fetchOpenClawRuntime() {
       updateChannel: status.updateChannel || null,
       updateInfo: status.update?.registry || null,
       secretDiagnostics: status.secretDiagnostics || [],
+      activeSessions: activity.activeSessions,
+      recentRuns: activity.recentRuns,
       updatedAt,
     };
   } catch (error) {

--- a/test/api-smoke.test.js
+++ b/test/api-smoke.test.js
@@ -76,6 +76,8 @@ function createTestApp({ cacheOverrides = {}, sourceOverrides = {}, infraError =
       nodeService: { label: 'systemd', installed: false, loaded: false, managedByOpenClaw: false, externallyManaged: false, runtime: { status: 'stopped', state: 'inactive' }, runtimeShort: 'stopped (state inactive)' },
       agents: { defaultId: 'main', agents: [{ id: 'main', name: 'main', workspaceDir: '/tmp/workspace', bootstrapPending: false, sessionsPath: '/tmp/sessions.json', sessionsCount: 16 }], totalSessions: 16, bootstrapPendingCount: 0 },
       memoryPlugin: { enabled: true, slot: 'memory-core' },
+      activeSessions: [{ key: 'agent:main:discord:direct:123', sessionId: 'sid-1', agent: 'main', type: 'direct', name: 'Tony DM', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 60000, active: true, percentUsed: 12, totalTokens: 3200, contextTokens: 272000, estimatedCostUsd: 0.01, chatType: 'direct', label: 'Tony DM', subject: null, spawnedBy: null, abortedLastRun: false }],
+      recentRuns: [{ key: 'agent:main:cron:test:run:sid-2', sessionId: 'sid-2', agent: 'main', type: 'run', name: 'Daily Standup', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 120000, active: false, percentUsed: 8, totalTokens: 2800, contextTokens: 272000, estimatedCostUsd: 0.02, chatType: 'direct', label: 'Daily Standup', subject: null, spawnedBy: null, abortedLastRun: false, durationSec: 45, status: 'completed' }],
       updateAvailable: false,
       updateChannel: 'stable',
       updateInfo: { latestVersion: '2026.4.14' },
@@ -146,6 +148,8 @@ test('main API routes return smoke-level shapes', async () => {
       assert.equal(openClaw.ok, true);
       assert.equal(openClaw.gateway.reachable, true);
       assert.equal(openClaw.agents.totalSessions, 16);
+      assert.equal(openClaw.activeSessions.length, 1);
+      assert.equal(openClaw.recentRuns.length, 1);
     });
   } finally {
     cleanup();


### PR DESCRIPTION
## Summary
- add OpenClaw active session and recent run activity data to `/api/openclaw`
- surface live session metadata, model usage, token/context usage, and recent run duration in the Angular OpenClaw view
- make the analytics table shell theme-aware so it stays light in light mode

## Testing
- npm test
- npm --prefix frontend run build
- verified `/api/openclaw` on an isolated local server config and confirmed active session + recent run data

Closes #52