### PR TITLE
Improve danger pill contrast across shared UI

### DIFF
--- a/frontend/src/app/features/issues/issue-list.page.ts
+++ b/frontend/src/app/features/issues/issue-list.page.ts
@@ -288,7 +288,7 @@ export class IssueListPage {
   }
 
   protected priorityBadgeClass(issue: IssueItem): string {
-    if (issue.priority === 'urgent') return 'cc-label-pill border-rose-400/25 bg-rose-500/10 text-rose-100';
+    if (issue.priority === 'urgent') return 'cc-label-pill border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]';
     if (issue.priority === 'active') return 'cc-label-pill border-sky-400/25 bg-sky-500/10 text-sky-100';
     return 'cc-label-pill border-white/10 bg-white/5 text-[var(--cc-text-muted)]';
   }

--- a/frontend/src/app/features/prs/prs.page.ts
+++ b/frontend/src/app/features/prs/prs.page.ts
@@ -208,14 +208,14 @@ export class PrsPage {
   }
 
   protected reviewBadgeClass(pr: PullRequestItem): string {
-    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'cc-label-pill border-rose-400/25 bg-rose-500/10 text-rose-100';
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'cc-label-pill border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]';
     if (pr.reviewDecision === 'APPROVED') return 'cc-label-pill border-emerald-400/25 bg-emerald-500/10 text-emerald-100';
     if (pr.isDraft) return 'cc-label-pill border-white/10 bg-white/5 text-[var(--cc-text-muted)]';
     return 'cc-label-pill border-sky-400/25 bg-sky-500/10 text-sky-100';
   }
 
   protected attentionBadgeClass(pr: PullRequestItem): string {
-    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'cc-label-pill border-rose-400/25 bg-rose-500/10 text-rose-100';
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'cc-label-pill border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]';
     if (pr.reviewDecision === 'APPROVED') return 'cc-label-pill border-emerald-400/25 bg-emerald-500/10 text-emerald-100';
     if (pr.isDraft) return 'cc-label-pill border-white/10 bg-white/5 text-[var(--cc-text-muted)]';
     return 'cc-label-pill border-amber-400/25 bg-amber-500/10 text-amber-100';

--- a/frontend/src/app/shared/ui/pill.component.ts
+++ b/frontend/src/app/shared/ui/pill.component.ts
@@ -18,7 +18,7 @@ export class PillComponent {
       accent: 'border-indigo-400/25 bg-indigo-500/10 text-indigo-100',
       success: 'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
       warning: 'border-amber-400/25 bg-amber-500/10 text-amber-100',
-      danger: 'border-rose-400/25 bg-rose-500/10 text-rose-100',
+      danger: 'border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]',
       info: 'border-sky-400/25 bg-sky-500/10 text-sky-100',
     } as const;
 

--- a/frontend/src/app/shared/ui/state-panel.component.ts
+++ b/frontend/src/app/shared/ui/state-panel.component.ts
@@ -46,7 +46,7 @@ export class StatePanelComponent {
     const tones = {
       loading: 'bg-white/5',
       empty: 'bg-white/5',
-      unavailable: 'bg-rose-500/15 text-rose-100',
+      unavailable: 'bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]',
     } as const;
 
     return tones[this.kind()];

--- a/frontend/src/app/shared/ui/status-badge.component.ts
+++ b/frontend/src/app/shared/ui/status-badge.component.ts
@@ -17,7 +17,7 @@ export class StatusBadgeComponent {
       neutral: 'border-[var(--cc-border)] bg-white/5 text-[var(--cc-text-soft)]',
       success: 'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
       warning: 'border-amber-400/25 bg-amber-500/10 text-amber-100',
-      danger: 'border-rose-400/25 bg-rose-500/10 text-rose-100',
+      danger: 'border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]',
       info: 'border-sky-400/25 bg-sky-500/10 text-sky-100',
     } as const;
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -14,6 +14,9 @@
   --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(56, 189, 248, 0.14));
   --cc-table-surface: rgba(15, 23, 42, 0.65);
   --cc-table-shadow: 0 30px 90px -48px rgba(15, 23, 42, 1);
+  --cc-danger-border: rgba(251, 113, 133, 0.28);
+  --cc-danger-surface: rgba(244, 63, 94, 0.12);
+  --cc-danger-text: #ffe4e6;
   --cc-border: rgba(148, 163, 184, 0.16);
   --cc-border-strong: rgba(255, 255, 255, 0.16);
   --cc-text: #e5edf8;
@@ -36,6 +39,9 @@ html.light {
   --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(56, 189, 248, 0.09));
   --cc-table-surface: rgba(255, 255, 255, 0.82);
   --cc-table-shadow: 0 30px 90px -48px rgba(15, 23, 42, 0.16);
+  --cc-danger-border: rgba(251, 113, 133, 0.34);
+  --cc-danger-surface: rgba(244, 63, 94, 0.12);
+  --cc-danger-text: #881337;
   --cc-border: rgba(15, 23, 42, 0.08);
   --cc-border-strong: rgba(15, 23, 42, 0.12);
   --cc-text: #0f172a;
@@ -242,9 +248,9 @@ code {
 }
 
 .cc-small-button-danger {
-  border-color: rgba(251, 113, 133, 0.28);
-  background: rgba(244, 63, 94, 0.12);
-  color: #ffe4e6;
+  border-color: var(--cc-danger-border);
+  background: var(--cc-danger-surface);
+  color: var(--cc-danger-text);
 }
 
 .cc-label-pill {


### PR DESCRIPTION
## Summary
- replace the low-contrast light rose danger text with theme-aware danger tokens
- apply the fix to shared pill, status badge, and small danger button styling
- update issue and PR views so danger labels inherit the shared readable contrast

## Testing
- npm test

Closes #92