### PR TITLE
Improve info pill contrast across shared UI

### DIFF
--- a/frontend/src/app/features/issues/issue-list.page.ts
+++ b/frontend/src/app/features/issues/issue-list.page.ts
@@ -289,7 +289,7 @@ export class IssueListPage {
 
   protected priorityBadgeClass(issue: IssueItem): string {
     if (issue.priority === 'urgent') return 'cc-label-pill border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]';
-    if (issue.priority === 'active') return 'cc-label-pill border-sky-400/25 bg-sky-500/10 text-sky-100';
+    if (issue.priority === 'active') return 'cc-label-pill border-[var(--cc-info-border)] bg-[var(--cc-info-surface)] text-[var(--cc-info-text)]';
     return 'cc-label-pill border-white/10 bg-white/5 text-[var(--cc-text-muted)]';
   }
 

--- a/frontend/src/app/features/prs/prs.page.ts
+++ b/frontend/src/app/features/prs/prs.page.ts
@@ -211,7 +211,7 @@ export class PrsPage {
     if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'cc-label-pill border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]';
     if (pr.reviewDecision === 'APPROVED') return 'cc-label-pill border-emerald-400/25 bg-emerald-500/10 text-emerald-100';
     if (pr.isDraft) return 'cc-label-pill border-white/10 bg-white/5 text-[var(--cc-text-muted)]';
-    return 'cc-label-pill border-sky-400/25 bg-sky-500/10 text-sky-100';
+    return 'cc-label-pill border-[var(--cc-info-border)] bg-[var(--cc-info-surface)] text-[var(--cc-info-text)]';
   }
 
   protected attentionBadgeClass(pr: PullRequestItem): string {

--- a/frontend/src/app/shared/ui/pill.component.ts
+++ b/frontend/src/app/shared/ui/pill.component.ts
@@ -15,11 +15,11 @@ export class PillComponent {
     const base = 'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em]';
     const tones = {
       neutral: 'border-[var(--cc-border)] bg-white/5 text-[var(--cc-text-soft)]',
-      accent: 'border-indigo-400/25 bg-indigo-500/10 text-indigo-100',
+      accent: 'border-[var(--cc-accent-border)] bg-[var(--cc-accent-surface)] text-[var(--cc-accent-text)]',
       success: 'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
       warning: 'border-amber-400/25 bg-amber-500/10 text-amber-100',
       danger: 'border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]',
-      info: 'border-sky-400/25 bg-sky-500/10 text-sky-100',
+      info: 'border-[var(--cc-info-border)] bg-[var(--cc-info-surface)] text-[var(--cc-info-text)]',
     } as const;
 
     return `${base} ${tones[this.tone()]}`;

--- a/frontend/src/app/shared/ui/status-badge.component.ts
+++ b/frontend/src/app/shared/ui/status-badge.component.ts
@@ -18,7 +18,7 @@ export class StatusBadgeComponent {
       success: 'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
       warning: 'border-amber-400/25 bg-amber-500/10 text-amber-100',
       danger: 'border-[var(--cc-danger-border)] bg-[var(--cc-danger-surface)] text-[var(--cc-danger-text)]',
-      info: 'border-sky-400/25 bg-sky-500/10 text-sky-100',
+      info: 'border-[var(--cc-info-border)] bg-[var(--cc-info-surface)] text-[var(--cc-info-text)]',
     } as const;
 
     return `${base} ${tones[this.tone()]}`;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -14,6 +14,12 @@
   --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(56, 189, 248, 0.14));
   --cc-table-surface: rgba(15, 23, 42, 0.65);
   --cc-table-shadow: 0 30px 90px -48px rgba(15, 23, 42, 1);
+  --cc-accent-border: rgba(129, 140, 248, 0.28);
+  --cc-accent-surface: rgba(99, 102, 241, 0.14);
+  --cc-accent-text: #e0e7ff;
+  --cc-info-border: rgba(56, 189, 248, 0.28);
+  --cc-info-surface: rgba(14, 165, 233, 0.12);
+  --cc-info-text: #e0f2fe;
   --cc-danger-border: rgba(251, 113, 133, 0.28);
   --cc-danger-surface: rgba(244, 63, 94, 0.12);
   --cc-danger-text: #ffe4e6;
@@ -39,6 +45,12 @@ html.light {
   --cc-surface-highlight: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(56, 189, 248, 0.09));
   --cc-table-surface: rgba(255, 255, 255, 0.82);
   --cc-table-shadow: 0 30px 90px -48px rgba(15, 23, 42, 0.16);
+  --cc-accent-border: rgba(129, 140, 248, 0.34);
+  --cc-accent-surface: rgba(99, 102, 241, 0.12);
+  --cc-accent-text: #3730a3;
+  --cc-info-border: rgba(56, 189, 248, 0.34);
+  --cc-info-surface: rgba(14, 165, 233, 0.12);
+  --cc-info-text: #0c4a6e;
   --cc-danger-border: rgba(251, 113, 133, 0.34);
   --cc-danger-surface: rgba(244, 63, 94, 0.12);
   --cc-danger-text: #881337;
@@ -242,9 +254,9 @@ code {
 }
 
 .cc-small-button-accent {
-  border-color: rgba(99, 102, 241, 0.24);
-  background: rgba(99, 102, 241, 0.14);
-  color: #dbeafe;
+  border-color: var(--cc-accent-border);
+  background: var(--cc-accent-surface);
+  color: var(--cc-accent-text);
 }
 
 .cc-small-button-danger {


### PR DESCRIPTION
## Summary
- replace the low-contrast light blue/info foreground with theme-aware accent and info tokens
- apply the fix to shared pill, status badge, and accent button styling
- update issue and PR view badges so blue/info labels stay readable in light mode

## Testing
- npm test

