### PR TITLE
Add OpenClaw log tail and grouped error feed

### DIFF
--- a/frontend/src/app/core/data/dashboard-data.service.ts
+++ b/frontend/src/app/core/data/dashboard-data.service.ts
@@ -48,6 +48,9 @@ export class DashboardDataService {
     channelSummary: OpenClawResponse['channelSummary'];
     activeSessions: OpenClawResponse['activeSessions'];
     recentRuns: OpenClawResponse['recentRuns'];
+    logsTail: OpenClawResponse['logsTail'];
+    errorFeed: OpenClawResponse['errorFeed'];
+    logsError: OpenClawResponse['logsError'];
     updateAvailable: OpenClawResponse['updateAvailable'];
     updateChannel: OpenClawResponse['updateChannel'];
     updateInfo: OpenClawResponse['updateInfo'];
@@ -163,6 +166,9 @@ export class DashboardDataService {
     channelSummary: OpenClawResponse['channelSummary'];
     activeSessions: OpenClawResponse['activeSessions'];
     recentRuns: OpenClawResponse['recentRuns'];
+    logsTail: OpenClawResponse['logsTail'];
+    errorFeed: OpenClawResponse['errorFeed'];
+    logsError: OpenClawResponse['logsError'];
     updateAvailable: OpenClawResponse['updateAvailable'];
     updateChannel: OpenClawResponse['updateChannel'];
     updateInfo: OpenClawResponse['updateInfo'];
@@ -186,6 +192,9 @@ export class DashboardDataService {
         channelSummary: response.channelSummary,
         activeSessions: response.activeSessions,
         recentRuns: response.recentRuns,
+        logsTail: response.logsTail,
+        errorFeed: response.errorFeed,
+        logsError: response.logsError,
         updateAvailable: response.updateAvailable,
         updateChannel: response.updateChannel,
         updateInfo: response.updateInfo,

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -373,7 +373,10 @@ export class HomePage {
     if (!data) return 'runtime unavailable';
     const service = data.gatewayService?.runtime?.status || 'unknown service';
     const liveSessions = (data.activeSessions ?? []).filter((session) => session.active).length;
-    return `${service} · ${liveSessions} live sessions`;
+    const groupedIssues = data.errorFeed?.length || 0;
+    return groupedIssues > 0
+      ? `${service} · ${liveSessions} live sessions · ${groupedIssues} grouped issues`
+      : `${service} · ${liveSessions} live sessions`;
   });
   protected readonly upcomingEvents = computed(() => {
     return (this.calendar.data() ?? [])

--- a/frontend/src/app/features/openclaw/openclaw.page.ts
+++ b/frontend/src/app/features/openclaw/openclaw.page.ts
@@ -150,6 +150,82 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
           </article>
         </section>
 
+        <section class="grid gap-4 xl:grid-cols-[0.95fr_1.05fr]">
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Grouped runtime issues</div>
+                <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Warnings and errors that keep recurring</div>
+              </div>
+              <cc-pill [tone]="errorFeedCount() ? 'danger' : 'success'">{{ errorFeedCount() }} grouped</cc-pill>
+            </div>
+
+            @if (openClaw.data()!.logsError && !openClaw.data()!.errorFeed.length) {
+              <cc-state-panel class="mt-5" kind="unavailable" title="Grouped runtime issues unavailable" [message]="openClaw.data()!.logsError || 'Unable to collect OpenClaw runtime issues.'"></cc-state-panel>
+            } @else if (!openClaw.data()!.errorFeed.length) {
+              <cc-state-panel class="mt-5" kind="empty" title="No recurring runtime issues" message="Recent OpenClaw warnings and errors are currently quiet."></cc-state-panel>
+            } @else {
+              <div class="mt-5 space-y-3">
+                @for (group of openClaw.data()!.errorFeed; track group.signature) {
+                  <div class="cc-stat-surface p-4">
+                    <div class="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div class="text-sm font-semibold text-[var(--cc-text)]">{{ group.sampleMessage }}</div>
+                        <div class="mt-2 text-xs text-[var(--cc-text-soft)]">First seen {{ formatAgeFromTimestamp(group.firstSeen) }} · last seen {{ formatAgeFromTimestamp(group.lastSeen) }}</div>
+                      </div>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <cc-pill [tone]="logLevelTone(group.severity)">{{ group.severity }}</cc-pill>
+                        <cc-pill tone="info">{{ group.source }}</cc-pill>
+                        <cc-pill [tone]="group.count > 1 ? 'warning' : 'success'">{{ group.count }}x</cc-pill>
+                      </div>
+                    </div>
+                    <div class="mt-4 space-y-2">
+                      @for (occurrence of group.lastOccurrences; track occurrence.timestamp + ':' + occurrence.message) {
+                        <div class="rounded-2xl border border-[var(--cc-border)]/70 bg-[var(--cc-surface-muted)]/70 px-3 py-2 font-mono text-xs leading-5 text-[var(--cc-text-muted)]">
+                          <span class="text-[var(--cc-text-soft)]">{{ formatClock(occurrence.timestamp) }}</span>
+                          <span class="mx-2 text-[var(--cc-text-soft)]">·</span>
+                          <span>{{ occurrence.message }}</span>
+                        </div>
+                      }
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Recent log tail</div>
+                <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Latest OpenClaw runtime log lines</div>
+              </div>
+              <cc-pill tone="info">{{ openClaw.data()!.logsTail.length }} lines</cc-pill>
+            </div>
+
+            @if (openClaw.data()!.logsError && !openClaw.data()!.logsTail.length) {
+              <cc-state-panel class="mt-5" kind="unavailable" title="OpenClaw log tail unavailable" [message]="openClaw.data()!.logsError || 'Unable to collect OpenClaw logs.'"></cc-state-panel>
+            } @else if (!openClaw.data()!.logsTail.length) {
+              <cc-state-panel class="mt-5" kind="empty" title="No recent log lines" message="OpenClaw did not return any recent runtime log lines."></cc-state-panel>
+            } @else {
+              <div class="mt-5 space-y-3">
+                @for (entry of openClaw.data()!.logsTail; track entry.timestamp + ':' + entry.source + ':' + entry.message) {
+                  <div class="cc-stat-surface p-4">
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                      <div class="font-mono text-xs text-[var(--cc-text-soft)]">{{ formatClock(entry.timestamp) }}</div>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <cc-pill [tone]="logLevelTone(entry.level)">{{ entry.level }}</cc-pill>
+                        <cc-pill tone="info">{{ entry.source }}</cc-pill>
+                      </div>
+                    </div>
+                    <div class="mt-3 break-words font-mono text-xs leading-6 text-[var(--cc-text-muted)]">{{ entry.message }}</div>
+                  </div>
+                }
+              </div>
+            }
+          </article>
+        </section>
+
         <section class="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
           <article class="cc-list-card p-5">
             <div class="flex items-center justify-between gap-3">
@@ -261,11 +337,13 @@ export class OpenClawPage {
     return Boolean(latest && current && latest !== current);
   });
   protected readonly activeSessionCount = computed(() => (this.openClaw.data()?.activeSessions ?? []).filter((session) => session.active).length);
+  protected readonly errorFeedCount = computed(() => this.openClaw.data()?.errorFeed?.length || 0);
   protected readonly meta = computed(() => {
     const gateway = this.openClaw.data()?.gateway?.reachable ? 'gateway reachable' : 'gateway down';
     const service = this.openClaw.data()?.gatewayService?.runtime?.status || 'unknown service';
     const sessions = this.activeSessionCount();
-    return `${gateway} · ${service} · ${sessions} live sessions`;
+    const issues = this.errorFeedCount();
+    return `${gateway} · ${service} · ${sessions} live sessions · ${issues} grouped issues`;
   });
 
   protected onHeaderAction(actionId: string): void {
@@ -315,6 +393,13 @@ export class OpenClawPage {
     return 'warning';
   }
 
+  protected logLevelTone(level?: string | null): 'success' | 'danger' | 'warning' | 'info' {
+    if (level === 'error') return 'danger';
+    if (level === 'warn' || level === 'warning') return 'warning';
+    if (level === 'debug') return 'info';
+    return 'success';
+  }
+
   protected taskStatus(): string {
     const failures = this.openClaw.data()?.tasks?.failures || 0;
     const warnings = this.openClaw.data()?.taskAudit?.warnings || 0;
@@ -340,6 +425,16 @@ export class OpenClawPage {
   protected formatMemory(bytes?: number | null): string {
     if (!bytes) return 'memory unavailable';
     return `${(bytes / 1024 / 1024).toFixed(1)} MB RSS`;
+  }
+
+  protected formatAgeFromTimestamp(timestamp?: number | null): string {
+    if (!timestamp) return '—';
+    return this.formatAge(Math.max(0, Date.now() - timestamp));
+  }
+
+  protected formatClock(timestamp?: number | null): string {
+    if (!timestamp) return '—';
+    return new Date(timestamp).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
   }
 
   protected formatDuration(seconds?: number | null): string {

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -327,6 +327,32 @@ export interface OpenClawRunSummary extends OpenClawSessionSummary {
   status: string;
 }
 
+export interface OpenClawLogEntry {
+  timestamp: number;
+  seenAt: string;
+  level: string;
+  source: string;
+  message: string;
+}
+
+export interface OpenClawErrorOccurrence {
+  timestamp: number;
+  source: string;
+  level: string;
+  message: string;
+}
+
+export interface OpenClawErrorGroup {
+  signature: string;
+  source: string;
+  severity: string;
+  count: number;
+  firstSeen: number;
+  lastSeen: number;
+  sampleMessage: string;
+  lastOccurrences: OpenClawErrorOccurrence[];
+}
+
 export interface OpenClawResponse extends ApiEnvelope {
   version: string | null;
   gateway: OpenClawGateway | null;
@@ -342,6 +368,9 @@ export interface OpenClawResponse extends ApiEnvelope {
   channelSummary?: string[];
   activeSessions: OpenClawSessionSummary[];
   recentRuns: OpenClawRunSummary[];
+  logsTail: OpenClawLogEntry[];
+  errorFeed: OpenClawErrorGroup[];
+  logsError?: string | null;
   updateAvailable?: boolean | null;
   updateChannel?: string | null;
   updateInfo?: { latestVersion?: string | null } | null;

--- a/server.js
+++ b/server.js
@@ -632,9 +632,24 @@ function readProcessSnapshot(pid) {
 }
 
 const OPENCLAW_AGENTS_DIR = path.join(process.env.HOME || '', '.openclaw', 'agents');
+const OPENCLAW_CRON_RUNS_DIR = path.join(process.env.HOME || '', '.openclaw', 'cron', 'runs');
 const OPENCLAW_ACTIVE_WINDOW_MS = 30 * 60 * 1000;
 const OPENCLAW_RECENT_SESSION_MS = 24 * 60 * 60 * 1000;
 const OPENCLAW_RECENT_ACTIVITY_MS = 7 * 24 * 60 * 60 * 1000;
+const OPENCLAW_LOG_TAIL_LIMIT = 80;
+const OPENCLAW_LOG_MAX_BYTES = 180000;
+const OPENCLAW_LOG_TIMEOUT_MS = 10000;
+const OPENCLAW_ERROR_FEED_LIMIT = 12;
+const OPENCLAW_ERROR_OCCURRENCES_LIMIT = 3;
+const OPENCLAW_ERROR_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const OPENCLAW_UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const OPENCLAW_ID_TOKEN_RE = /\b(?:id|session|task|job|trace|request|pid|diagId|sessionKey|lane)[:=]?\s*[^\s,]+/gi;
+const OPENCLAW_URL_RE = /\b(?:ws|wss|https?):\/\/\S+/gi;
+const OPENCLAW_PATH_RE = /\/(?:home|tmp)\/[^\s]+/g;
+const OPENCLAW_AGENT_KEY_RE = /agent:[^\s]+/gi;
+const OPENCLAW_NUMERIC_RE = /\b\d+\b/g;
+const OPENCLAW_TIMESTAMP_RE = /\b\d{4}-\d{2}-\d{2}[t\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:z|[+\-]\d{2}:\d{2})?\b/gi;
 
 function readJsonFileSafe(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -785,6 +800,192 @@ function collectOpenClawActivity() {
   };
 }
 
+function cleanOpenClawLogMessage(message, maxLength = 320) {
+  if (!message) return '';
+
+  let cleaned = String(message)
+    .replace(/^\{[^}]+\}\s*/, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\sraw_params=.*$/i, ' raw_params=<omitted>')
+    .replace(/\saggregated=.*$/i, ' aggregated=<omitted>')
+    .trim();
+
+  if (cleaned.length > maxLength) {
+    cleaned = `${cleaned.slice(0, maxLength - 1)}…`;
+  }
+
+  return cleaned;
+}
+
+function normalizeOpenClawErrorSignature(message) {
+  return cleanOpenClawLogMessage(message, 500)
+    .toLowerCase()
+    .replace(OPENCLAW_TIMESTAMP_RE, '<ts>')
+    .replace(OPENCLAW_UUID_RE, '<uuid>')
+    .replace(OPENCLAW_ID_TOKEN_RE, '<id>')
+    .replace(OPENCLAW_URL_RE, '<url>')
+    .replace(OPENCLAW_PATH_RE, '<path>')
+    .replace(OPENCLAW_AGENT_KEY_RE, 'agent:<session>')
+    .replace(OPENCLAW_NUMERIC_RE, '<n>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function openClawLogSource(entry = {}) {
+  if (entry.subsystem) return String(entry.subsystem);
+
+  const message = String(entry.message || '');
+  const prefixMatch = message.match(/^\[([^\]]+)\]/);
+  if (prefixMatch) return prefixMatch[1];
+  if (/lane wait exceeded/i.test(message)) return 'diagnostic';
+  return 'gateway';
+}
+
+function readOpenClawLogTail() {
+  const raw = execFileSync('openclaw', [
+    'logs',
+    '--json',
+    '--limit',
+    String(OPENCLAW_LOG_TAIL_LIMIT),
+    '--max-bytes',
+    String(OPENCLAW_LOG_MAX_BYTES),
+    '--timeout',
+    String(OPENCLAW_LOG_TIMEOUT_MS),
+  ], {
+    encoding: 'utf8',
+    timeout: OPENCLAW_LOG_TIMEOUT_MS + 5000,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+
+  return raw
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(entry => entry && entry.type === 'log')
+    .map(entry => {
+      const timestamp = Date.parse(entry.time || '') || Date.now();
+      return {
+        timestamp,
+        seenAt: entry.time || new Date(timestamp).toISOString(),
+        level: String(entry.level || 'info').toLowerCase(),
+        source: openClawLogSource(entry),
+        message: cleanOpenClawLogMessage(entry.message || entry.raw || ''),
+      };
+    })
+    .filter(entry => entry.message)
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .slice(-OPENCLAW_LOG_TAIL_LIMIT);
+}
+
+function readRecentOpenClawCronErrors() {
+  if (!OPENCLAW_CRON_RUNS_DIR || !fs.existsSync(OPENCLAW_CRON_RUNS_DIR)) {
+    return [];
+  }
+
+  const threshold = Date.now() - OPENCLAW_ERROR_WINDOW_MS;
+  const files = fs.readdirSync(OPENCLAW_CRON_RUNS_DIR)
+    .filter(name => name.endsWith('.jsonl'))
+    .map(name => {
+      const fullPath = path.join(OPENCLAW_CRON_RUNS_DIR, name);
+      const stats = fs.statSync(fullPath);
+      return { fullPath, mtimeMs: stats.mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, 20);
+
+  const events = [];
+
+  for (const file of files) {
+    const lines = fs.readFileSync(file.fullPath, 'utf8').split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        const timestamp = Number(entry.ts || 0);
+        if (!timestamp || timestamp < threshold) continue;
+
+        const level = entry.status === 'error' ? 'error' : entry.status === 'warn' ? 'warn' : null;
+        if (!level) continue;
+
+        const message = cleanOpenClawLogMessage(entry.error || entry.summary || entry.message || entry.action || 'cron runtime error');
+        if (!message) continue;
+
+        events.push({
+          timestamp,
+          seenAt: new Date(timestamp).toISOString(),
+          level,
+          source: 'cron',
+          message,
+        });
+      } catch {
+        // ignore malformed lines
+      }
+    }
+  }
+
+  return events
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .slice(-OPENCLAW_LOG_TAIL_LIMIT);
+}
+
+function buildOpenClawErrorFeed(...collections) {
+  const threshold = Date.now() - OPENCLAW_ERROR_WINDOW_MS;
+  const groups = new Map();
+
+  for (const collection of collections) {
+    for (const entry of collection || []) {
+      if (!entry || !entry.message || (entry.level !== 'warn' && entry.level !== 'error')) continue;
+      if (entry.timestamp && entry.timestamp < threshold) continue;
+
+      const signature = `${entry.source}|${normalizeOpenClawErrorSignature(entry.message)}`;
+      if (!signature) continue;
+
+      const existing = groups.get(signature) || {
+        signature,
+        source: entry.source,
+        severity: entry.level,
+        count: 0,
+        firstSeen: entry.timestamp,
+        lastSeen: entry.timestamp,
+        sampleMessage: entry.message,
+        lastOccurrences: [],
+      };
+
+      existing.count += 1;
+      existing.firstSeen = Math.min(existing.firstSeen, entry.timestamp);
+      existing.lastSeen = Math.max(existing.lastSeen, entry.timestamp);
+      if (existing.severity !== 'error' && entry.level === 'error') {
+        existing.severity = 'error';
+      }
+      existing.lastOccurrences.push({
+        timestamp: entry.timestamp,
+        source: entry.source,
+        level: entry.level,
+        message: entry.message,
+      });
+      existing.lastOccurrences = existing.lastOccurrences
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .slice(-OPENCLAW_ERROR_OCCURRENCES_LIMIT);
+
+      groups.set(signature, existing);
+    }
+  }
+
+  return [...groups.values()]
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      if (a.severity !== b.severity) return a.severity === 'error' ? -1 : 1;
+      return b.lastSeen - a.lastSeen;
+    })
+    .slice(0, OPENCLAW_ERROR_FEED_LIMIT);
+}
+
 function fetchOpenClawRuntime() {
   beginSource('openclaw');
   try {
@@ -798,6 +999,23 @@ function fetchOpenClawRuntime() {
     const gatewayPid = status.gatewayService?.runtime?.pid;
     const gatewayProcess = readProcessSnapshot(gatewayPid);
     const activity = collectOpenClawActivity();
+    let logsTail = [];
+    let errorFeed = [];
+    let logsError = null;
+
+    try {
+      const runtimeLogs = readOpenClawLogTail();
+      const cronErrors = readRecentOpenClawCronErrors();
+      logsTail = runtimeLogs;
+      errorFeed = buildOpenClawErrorFeed(runtimeLogs, cronErrors);
+    } catch (error) {
+      logsError = error.message;
+      try {
+        errorFeed = buildOpenClawErrorFeed(readRecentOpenClawCronErrors());
+      } catch {
+        errorFeed = [];
+      }
+    }
 
     succeedSource('openclaw', updatedAt);
     return {
@@ -819,6 +1037,9 @@ function fetchOpenClawRuntime() {
       secretDiagnostics: status.secretDiagnostics || [],
       activeSessions: activity.activeSessions,
       recentRuns: activity.recentRuns,
+      logsTail,
+      errorFeed,
+      logsError,
       updatedAt,
     };
   } catch (error) {

--- a/test/api-smoke.test.js
+++ b/test/api-smoke.test.js
@@ -78,6 +78,9 @@ function createTestApp({ cacheOverrides = {}, sourceOverrides = {}, infraError =
       memoryPlugin: { enabled: true, slot: 'memory-core' },
       activeSessions: [{ key: 'agent:main:discord:direct:123', sessionId: 'sid-1', agent: 'main', type: 'direct', name: 'Tony DM', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 60000, active: true, percentUsed: 12, totalTokens: 3200, contextTokens: 272000, estimatedCostUsd: 0.01, chatType: 'direct', label: 'Tony DM', subject: null, spawnedBy: null, abortedLastRun: false }],
       recentRuns: [{ key: 'agent:main:cron:test:run:sid-2', sessionId: 'sid-2', agent: 'main', type: 'run', name: 'Daily Standup', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 120000, active: false, percentUsed: 8, totalTokens: 2800, contextTokens: 272000, estimatedCostUsd: 0.02, chatType: 'direct', label: 'Daily Standup', subject: null, spawnedBy: null, abortedLastRun: false, durationSec: 45, status: 'completed' }],
+      logsTail: [{ timestamp: 1713124800000, seenAt: '2026-04-15T12:00:00Z', level: 'error', source: 'tools', message: '[tools] read failed: ENOENT' }],
+      errorFeed: [{ signature: 'tools|enoent', source: 'tools', severity: 'error', count: 2, firstSeen: 1713124700000, lastSeen: 1713124800000, sampleMessage: '[tools] read failed: ENOENT', lastOccurrences: [{ timestamp: 1713124800000, source: 'tools', level: 'error', message: '[tools] read failed: ENOENT' }] }],
+      logsError: null,
       updateAvailable: false,
       updateChannel: 'stable',
       updateInfo: { latestVersion: '2026.4.14' },
@@ -150,6 +153,8 @@ test('main API routes return smoke-level shapes', async () => {
       assert.equal(openClaw.agents.totalSessions, 16);
       assert.equal(openClaw.activeSessions.length, 1);
       assert.equal(openClaw.recentRuns.length, 1);
+      assert.equal(openClaw.logsTail.length, 1);
+      assert.equal(openClaw.errorFeed.length, 1);
     });
   } finally {
     cleanup();


### PR DESCRIPTION
## Summary
- add real OpenClaw runtime log tail data to `/api/openclaw` using `openclaw logs --json`
- group recurring OpenClaw warnings and errors, including recent cron run failures, into a dashboard-friendly error feed
- surface the new log tail and grouped runtime issues on the OpenClaw page and bubble grouped issue count into the Home summary

## Testing
- npm test
- COMMAND_CENTER_CONFIG=/home/guntharp/.openclaw/workspace/tmp/command-center-test-config.json node - <<'NODE'
const { app } = require('./server');
(async () => {
  const server = app.listen(0, "127.0.0.1", async () => {
    const { port } = server.address();
    try {
      const openclaw = await fetch(`http://127.0.0.1:${port}/api/openclaw`).then(r => r.json());
      console.log(JSON.stringify({
        ok: openclaw.ok,
        activeSessions: openclaw.activeSessions?.length,
        recentRuns: openclaw.recentRuns?.length,
        logsTail: openclaw.logsTail?.length,
        errorFeed: openclaw.errorFeed?.length
      }, null, 2));
    } finally {
      server.close();
    }
  });
})();
NODE

Closes #53