### PR TITLE
Deduplicate overlapping calendar feed events

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -156,9 +156,74 @@ function extractDecisionSummary(content, fileName) {
   };
 }
 
+function normalizeCalendarText(value) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function calendarPreference(event) {
+  if (event?.calendar === 'Work') return 2;
+  if (event?.calendar === 'Personal') return 1;
+  return 0;
+}
+
+function calendarDetailScore(event) {
+  return ['location', 'description']
+    .filter(key => Boolean(event?.[key]))
+    .length;
+}
+
+function choosePreferredCalendarEvent(current, candidate) {
+  if (!current) return candidate;
+
+  const currentPreference = calendarPreference(current);
+  const candidatePreference = calendarPreference(candidate);
+
+  let winner = current;
+  let backup = candidate;
+
+  if (candidatePreference > currentPreference) {
+    winner = candidate;
+    backup = current;
+  } else if (candidatePreference === currentPreference) {
+    const currentDetailScore = calendarDetailScore(current);
+    const candidateDetailScore = calendarDetailScore(candidate);
+
+    if (candidateDetailScore > currentDetailScore) {
+      winner = candidate;
+      backup = current;
+    }
+  }
+
+  return {
+    ...winner,
+    location: winner.location || backup.location || null,
+    description: winner.description || backup.description || null,
+  };
+}
+
+function dedupeCalendarEvents(events = []) {
+  const deduped = new Map();
+
+  for (const event of events) {
+    const key = [
+      normalizeCalendarText(event.title),
+      event.start,
+      event.end,
+    ].join('|');
+
+    deduped.set(key, choosePreferredCalendarEvent(deduped.get(key), event));
+  }
+
+  return [...deduped.values()];
+}
+
 module.exports = {
   parseTaskRecord,
   parseStandupSections,
   extractDailyNotePreview,
   extractDecisionSummary,
+  dedupeCalendarEvents,
 };

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const {
   parseStandupSections,
   extractDailyNotePreview,
   extractDecisionSummary,
+  dedupeCalendarEvents,
 } = require('./lib/parsers');
 const { config: runtimeConfig, configPath, warnings: configWarnings } = loadConfig();
 const PORT = runtimeConfig.server.port;
@@ -473,13 +474,13 @@ async function fetchCalendars() {
       }
     }
 
-    // Sort by start time
-    allEvents.sort((a, b) => new Date(a.start) - new Date(b.start));
+    const dedupedEvents = dedupeCalendarEvents(allEvents)
+      .sort((a, b) => new Date(a.start) - new Date(b.start));
 
-    cache.events = allEvents;
+    cache.events = dedupedEvents;
     cache.eventsUpdatedAt = Date.now();
     succeedSource('calendar', cache.eventsUpdatedAt);
-    console.log(`[calendar] fetched ${allEvents.length} events`);
+    console.log(`[calendar] fetched ${dedupedEvents.length} events (${allEvents.length - dedupedEvents.length} duplicates collapsed)`);
   } catch (err) {
     failSource('calendar', err);
     console.error('[calendar] fetch error:', err.message);

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -8,6 +8,7 @@ const {
   parseStandupSections,
   extractDailyNotePreview,
   extractDecisionSummary,
+  dedupeCalendarEvents,
 } = require('../lib/parsers');
 
 test('parseTaskRecord strips metadata and keeps due date/recurring state', () => {
@@ -76,4 +77,57 @@ test('extractDecisionSummary prefers explicit metadata when present', () => {
     preview: 'This decision locks in Angular as the shipped frontend. Second supporting sentence with more context.',
     file: '2026-04-14-ship-angular',
   });
+});
+
+test('dedupeCalendarEvents prefers Work entries for duplicate events', () => {
+  const events = [
+    {
+      title: 'Flight to Denver (UA 2479)',
+      start: '2026-04-30T21:35:00.000Z',
+      end: '2026-04-30T23:57:00.000Z',
+      allDay: false,
+      calendar: 'Personal',
+      location: null,
+      description: 'Personal copy',
+    },
+    {
+      title: ' Flight   to Denver (UA 2479) ',
+      start: '2026-04-30T21:35:00.000Z',
+      end: '2026-04-30T23:57:00.000Z',
+      allDay: false,
+      calendar: 'Work',
+      location: 'San Antonio SAT',
+      description: null,
+    },
+  ];
+
+  const deduped = dedupeCalendarEvents(events);
+
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].calendar, 'Work');
+  assert.equal(deduped[0].location, 'San Antonio SAT');
+  assert.equal(deduped[0].description, 'Personal copy');
+});
+
+test('dedupeCalendarEvents keeps distinct events when times differ', () => {
+  const events = [
+    {
+      title: 'Bellamy Brothers',
+      start: '2026-05-09T00:00:00.000Z',
+      end: '2026-05-09T00:30:00.000Z',
+      allDay: false,
+      calendar: 'Personal',
+    },
+    {
+      title: 'Bellamy Brothers',
+      start: '2026-05-09T01:00:00.000Z',
+      end: '2026-05-09T01:30:00.000Z',
+      allDay: false,
+      calendar: 'Work',
+    },
+  ];
+
+  const deduped = dedupeCalendarEvents(events);
+
+  assert.equal(deduped.length, 2);
 });


### PR DESCRIPTION
## Summary
- dedupe calendar events across feeds using normalized title + start + end
- prefer Work entries when the same event appears in both Work and Personal feeds
- backfill missing location/description from the duplicate copy and add parser tests

## Testing
- npm test
- live isolated /api/calendar check on 127.0.0.1:4551 against the real configured feeds

Closes #99