### PR TITLE
Add OpenClaw token and cost analytics

### DIFF
--- a/frontend/src/app/core/data/dashboard-data.service.ts
+++ b/frontend/src/app/core/data/dashboard-data.service.ts
@@ -48,6 +48,7 @@ export class DashboardDataService {
     channelSummary: OpenClawResponse['channelSummary'];
     activeSessions: OpenClawResponse['activeSessions'];
     recentRuns: OpenClawResponse['recentRuns'];
+    usageAnalytics: OpenClawResponse['usageAnalytics'];
     logsTail: OpenClawResponse['logsTail'];
     errorFeed: OpenClawResponse['errorFeed'];
     logsError: OpenClawResponse['logsError'];
@@ -166,6 +167,7 @@ export class DashboardDataService {
     channelSummary: OpenClawResponse['channelSummary'];
     activeSessions: OpenClawResponse['activeSessions'];
     recentRuns: OpenClawResponse['recentRuns'];
+    usageAnalytics: OpenClawResponse['usageAnalytics'];
     logsTail: OpenClawResponse['logsTail'];
     errorFeed: OpenClawResponse['errorFeed'];
     logsError: OpenClawResponse['logsError'];
@@ -192,6 +194,7 @@ export class DashboardDataService {
         channelSummary: response.channelSummary,
         activeSessions: response.activeSessions,
         recentRuns: response.recentRuns,
+        usageAnalytics: response.usageAnalytics,
         logsTail: response.logsTail,
         errorFeed: response.errorFeed,
         logsError: response.logsError,

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -374,9 +374,13 @@ export class HomePage {
     const service = data.gatewayService?.runtime?.status || 'unknown service';
     const liveSessions = (data.activeSessions ?? []).filter((session) => session.active).length;
     const groupedIssues = data.errorFeed?.length || 0;
-    return groupedIssues > 0
-      ? `${service} · ${liveSessions} live sessions · ${groupedIssues} grouped issues`
-      : `${service} · ${liveSessions} live sessions`;
+    const todaySpend = data.usageAnalytics?.windows?.today?.totalCostUsd;
+    const spendLabel = todaySpend != null ? `$${todaySpend.toFixed(2)} today` : null;
+
+    const parts = [`${service}`, `${liveSessions} live sessions`];
+    if (spendLabel) parts.push(spendLabel);
+    if (groupedIssues > 0) parts.push(`${groupedIssues} grouped issues`);
+    return parts.join(' · ');
   });
   protected readonly upcomingEvents = computed(() => {
     return (this.calendar.data() ?? [])

--- a/frontend/src/app/features/openclaw/openclaw.page.ts
+++ b/frontend/src/app/features/openclaw/openclaw.page.ts
@@ -1,15 +1,17 @@
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 
 import { DashboardDataService } from '../../core/data/dashboard-data.service';
+import type { OpenClawUsageDay, OpenClawUsageModel, OpenClawUsageWindow, OpenClawUsageWindowKey } from '../../models/api';
 import { ViewShellComponent } from '../../layout/view-shell.component';
 import { STANDARD_PANEL_ACTIONS } from '../../shared/models/panel-action';
 import { PanelActionsComponent } from '../../shared/ui/panel-actions.component';
 import { PillComponent } from '../../shared/ui/pill.component';
 import { StatePanelComponent } from '../../shared/ui/state-panel.component';
+import { TrendBarsComponent } from '../../shared/ui/trend-bars.component';
 
 @Component({
   selector: 'app-openclaw-page',
-  imports: [ViewShellComponent, PanelActionsComponent, PillComponent, StatePanelComponent],
+  imports: [ViewShellComponent, PanelActionsComponent, PillComponent, StatePanelComponent, TrendBarsComponent],
   template: `
     <app-view-shell eyebrow="OpenClaw" title="OpenClaw Runtime" subtitle="Gateway reachability, service state, agents, and the local runtime posture without leaving command-center." [meta]="meta()">
       <div view-actions class="flex flex-wrap items-center gap-3">
@@ -147,6 +149,111 @@ import { StatePanelComponent } from '../../shared/ui/state-panel.component';
               <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Warnings</div><div class="mt-2 text-2xl font-semibold text-amber-300">{{ openClaw.data()!.taskAudit?.warnings || 0 }}</div></div>
               <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Errors</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ openClaw.data()!.taskAudit?.errors || 0 }}</div></div>
             </div>
+          </article>
+        </section>
+
+        <section class="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+          <article class="cc-list-card p-5">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Token and cost analytics</div>
+                <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Model usage over time</div>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                @for (window of usageWindowOptions; track window.key) {
+                  <button type="button" (click)="selectUsageWindow(window.key)" class="cc-small-button rounded-full px-3 py-1.5 text-xs" [class.cc-small-button-accent]="selectedUsageWindow() === window.key">
+                    {{ window.label }}
+                  </button>
+                }
+              </div>
+            </div>
+
+            @if (!openClaw.data()!.usageAnalytics.usageEvents) {
+              <cc-state-panel class="mt-5" kind="empty" title="No OpenClaw usage data yet" message="Assistant token and cost analytics will appear here once OpenClaw records usage-bearing responses."></cc-state-panel>
+            } @else if (!selectedUsageWindowData() || !selectedUsageWindowData()!.calls) {
+              <cc-state-panel class="mt-5" kind="empty" title="No usage in this window" message="Try another time range to see recorded token and cost activity."></cc-state-panel>
+            } @else {
+              <div class="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Spend</div><div class="mt-2 text-2xl font-semibold text-emerald-300">{{ formatCost(selectedUsageWindowData()!.totalCostUsd) }}</div><div class="mt-2 text-xs text-[var(--cc-text-soft)]">{{ usageCoverageText() }}</div></div>
+                <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Input</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ formatTokenCount(selectedUsageWindowData()!.inputTokens) }}</div><div class="mt-2 text-xs text-[var(--cc-text-soft)]">prompt tokens</div></div>
+                <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Output</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ formatTokenCount(selectedUsageWindowData()!.outputTokens) }}</div><div class="mt-2 text-xs text-[var(--cc-text-soft)]">completion tokens</div></div>
+                <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Cache read</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ formatTokenCount(selectedUsageWindowData()!.cacheReadTokens) }}</div><div class="mt-2 text-xs text-[var(--cc-text-soft)]">reused tokens</div></div>
+                <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Cache write</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ formatTokenCount(selectedUsageWindowData()!.cacheWriteTokens) }}</div><div class="mt-2 text-xs text-[var(--cc-text-soft)]">new cache tokens</div></div>
+                <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Total tokens</div><div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ formatTokenCount(selectedUsageWindowData()!.totalTokens) }}</div><div class="mt-2 text-xs text-[var(--cc-text-soft)]">all assistant calls</div></div>
+                <div class="cc-stat-surface p-4"><div class="text-xs uppercase tracking-[0.18em] text-[var(--cc-text-soft)]">Top model</div><div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">{{ usageTopModel() }}</div><div class="mt-2 text-xs text-[var(--cc-text-soft)]">{{ selectedUsageWindowData()!.calls }} assistant calls</div></div>
+              </div>
+
+              <div class="mt-5 flex flex-wrap items-center justify-between gap-3 text-xs text-[var(--cc-text-soft)]">
+                <div>{{ usageFootnote() }}</div>
+                <cc-pill [tone]="selectedUsageWindowData()!.costAvailableCalls === selectedUsageWindowData()!.calls ? 'success' : 'warning'">{{ selectedUsageWindowData()!.costAvailableCalls }}/{{ selectedUsageWindowData()!.calls }} costed</cc-pill>
+              </div>
+
+              <div class="mt-5 space-y-3">
+                @for (model of selectedUsageModels(); track model.model) {
+                  <div class="cc-stat-surface p-4">
+                    <div class="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div class="text-sm font-semibold text-[var(--cc-text)]">{{ model.model }}</div>
+                        <div class="mt-2 text-xs text-[var(--cc-text-soft)]">Last seen {{ formatAgeFromTimestamp(model.lastSeenAt) }}</div>
+                      </div>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <cc-pill tone="info">{{ model.calls }} calls</cc-pill>
+                        <cc-pill [tone]="model.costAvailableCalls ? 'success' : 'warning'">{{ formatCost(model.totalCostUsd) }}</cc-pill>
+                        <cc-pill [tone]="modelUsageShareTone(model)">{{ modelUsageShareLabel(model) }}</cc-pill>
+                      </div>
+                    </div>
+                    <dl class="mt-4 grid gap-3 text-sm text-[var(--cc-text-muted)] md:grid-cols-3 xl:grid-cols-6">
+                      <div><dt class="text-[var(--cc-text-soft)]">Input</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatTokenCount(model.inputTokens) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Output</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatTokenCount(model.outputTokens) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Cache read</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatTokenCount(model.cacheReadTokens) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Cache write</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatTokenCount(model.cacheWriteTokens) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Total</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatTokenCount(model.totalTokens) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Spend</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatCost(model.totalCostUsd) }}</dd></div>
+                    </dl>
+                  </div>
+                }
+              </div>
+            }
+          </article>
+
+          <article class="cc-list-card p-5">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--cc-text-soft)]">Spend trend</div>
+                <div class="mt-2 text-lg font-semibold text-[var(--cc-text)]">Daily usage shape</div>
+              </div>
+              <cc-pill tone="info">{{ selectedUsageWindowData()?.daily?.length || 0 }} days</cc-pill>
+            </div>
+
+            @if (!selectedUsageWindowData() || !selectedUsageWindowData()!.daily.length) {
+              <cc-state-panel class="mt-5" kind="empty" title="No daily usage trend" message="Daily model spend and token activity will show up here for the selected window."></cc-state-panel>
+            } @else {
+              <div class="cc-stat-surface mt-5 p-4">
+                <div class="text-sm font-semibold text-[var(--cc-text)]">Daily spend</div>
+                <div class="mt-3 flex items-end gap-4">
+                  <cc-trend-bars class="flex-1" [values]="selectedUsageCostTrend()" tone="emerald" [compact]="false"></cc-trend-bars>
+                  <div class="max-w-40 text-xs leading-5 text-[var(--cc-text-soft)]">{{ usageCoverageText() }}</div>
+                </div>
+              </div>
+
+              <div class="mt-4 space-y-3">
+                @for (day of selectedUsageDailyPreview(); track day.date) {
+                  <div class="cc-stat-surface p-4">
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <div class="text-sm font-semibold text-[var(--cc-text)]">{{ formatUsageDate(day.date) }}</div>
+                        <div class="mt-2 text-xs text-[var(--cc-text-soft)]">{{ day.calls }} assistant calls</div>
+                      </div>
+                      <cc-pill [tone]="day.totalCostUsd ? 'success' : 'warning'">{{ formatCost(day.totalCostUsd) }}</cc-pill>
+                    </div>
+                    <dl class="mt-4 grid grid-cols-2 gap-3 text-sm text-[var(--cc-text-muted)]">
+                      <div><dt class="text-[var(--cc-text-soft)]">Tokens</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatTokenCount(day.totalTokens) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Cache read</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatTokenCount(day.cacheReadTokens) }}</dd></div>
+                    </dl>
+                  </div>
+                }
+              </div>
+            }
           </article>
         </section>
 
@@ -329,6 +436,13 @@ export class OpenClawPage {
 
   protected readonly openClaw = this.data.openClaw();
   protected readonly headerActions = STANDARD_PANEL_ACTIONS;
+  protected readonly usageWindowOptions: ReadonlyArray<{ key: OpenClawUsageWindowKey; label: string }> = [
+    { key: 'today', label: 'Today' },
+    { key: '7d', label: '7d' },
+    { key: '30d', label: '30d' },
+    { key: 'all', label: 'All time' },
+  ];
+  protected readonly selectedUsageWindow = signal<OpenClawUsageWindowKey>('7d');
   protected readonly currentVersion = computed(() => this.openClaw.data()?.version || this.openClaw.data()?.gateway?.self?.version || 'unknown');
   protected readonly latestVersion = computed(() => this.openClaw.data()?.updateInfo?.latestVersion || 'available');
   protected readonly showUpdateBadge = computed(() => {
@@ -338,12 +452,32 @@ export class OpenClawPage {
   });
   protected readonly activeSessionCount = computed(() => (this.openClaw.data()?.activeSessions ?? []).filter((session) => session.active).length);
   protected readonly errorFeedCount = computed(() => this.openClaw.data()?.errorFeed?.length || 0);
+  protected readonly selectedUsageWindowData = computed<OpenClawUsageWindow | null>(() => this.openClaw.data()?.usageAnalytics?.windows?.[this.selectedUsageWindow()] ?? null);
+  protected readonly selectedUsageModels = computed<OpenClawUsageModel[]>(() => (this.selectedUsageWindowData()?.models ?? []).slice(0, 8));
+  protected readonly selectedUsageCostTrend = computed<number[]>(() => (this.selectedUsageWindowData()?.daily ?? []).slice(-14).map((day) => day.totalCostUsd ?? 0));
+  protected readonly selectedUsageDailyPreview = computed<OpenClawUsageDay[]>(() => [...(this.selectedUsageWindowData()?.daily ?? [])].slice(-7).reverse());
+  protected readonly usageTopModel = computed(() => this.selectedUsageModels()[0]?.model || '—');
+  protected readonly usageCoverageText = computed(() => {
+    const window = this.selectedUsageWindowData();
+    if (!window || !window.calls) return 'No assistant responses in this window.';
+    if (window.costAvailableCalls === window.calls) return `Cost available for all ${window.calls} calls.`;
+    return `Cost available for ${window.costAvailableCalls} of ${window.calls} calls.`;
+  });
+  protected readonly usageFootnote = computed(() => {
+    const usage = this.openClaw.data()?.usageAnalytics;
+    if (!usage) return 'Usage analytics unavailable.';
+    const duplicates = usage.duplicateEvents ? `, deduped ${usage.duplicateEvents} duplicate entries` : '';
+    return `${usage.usageEvents} assistant calls across ${usage.filesScanned} transcript files${duplicates}.`;
+  });
   protected readonly meta = computed(() => {
     const gateway = this.openClaw.data()?.gateway?.reachable ? 'gateway reachable' : 'gateway down';
     const service = this.openClaw.data()?.gatewayService?.runtime?.status || 'unknown service';
     const sessions = this.activeSessionCount();
     const issues = this.errorFeedCount();
-    return `${gateway} · ${service} · ${sessions} live sessions · ${issues} grouped issues`;
+    const spend = this.openClaw.data()?.usageAnalytics?.windows?.today?.totalCostUsd;
+    return spend != null
+      ? `${gateway} · ${service} · ${sessions} live sessions · ${issues} grouped issues · $${spend.toFixed(2)} today`
+      : `${gateway} · ${service} · ${sessions} live sessions · ${issues} grouped issues`;
   });
 
   protected onHeaderAction(actionId: string): void {
@@ -355,6 +489,10 @@ export class OpenClawPage {
     if (actionId === 'copy') {
       void this.copyLink();
     }
+  }
+
+  protected selectUsageWindow(window: OpenClawUsageWindowKey): void {
+    this.selectedUsageWindow.set(window);
   }
 
   protected gatewayTone(): 'success' | 'danger' | 'warning' {
@@ -450,6 +588,44 @@ export class OpenClawPage {
   protected formatCost(value?: number | null): string {
     if (value == null) return '—';
     return `$${value.toFixed(4)}`;
+  }
+
+  protected formatTokenCount(value?: number | null): string {
+    if (value == null) return '—';
+    return new Intl.NumberFormat('en-US', { notation: value >= 1000 ? 'compact' : 'standard', maximumFractionDigits: value >= 1000 ? 1 : 0 }).format(value);
+  }
+
+  protected formatUsageDate(date: string): string {
+    return new Date(`${date}T00:00:00`).toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
+
+  protected modelUsageShareLabel(model: OpenClawUsageModel): string {
+    const window = this.selectedUsageWindowData();
+    if (!window) return '—';
+
+    if (window.totalCostUsd && model.totalCostUsd != null) {
+      const share = (model.totalCostUsd / window.totalCostUsd) * 100;
+      return `${Math.max(1, Math.round(share))}% spend`;
+    }
+
+    if (!window.totalTokens) return '—';
+    const share = (model.totalTokens / window.totalTokens) * 100;
+    return `${Math.max(1, Math.round(share))}% tokens`;
+  }
+
+  protected modelUsageShareTone(model: OpenClawUsageModel): 'success' | 'warning' | 'info' {
+    const window = this.selectedUsageWindowData();
+    if (!window) return 'info';
+
+    const basis = window.totalCostUsd && model.totalCostUsd != null
+      ? (model.totalCostUsd / window.totalCostUsd) * 100
+      : window.totalTokens
+        ? (model.totalTokens / window.totalTokens) * 100
+        : 0;
+
+    if (basis >= 50) return 'warning';
+    if (basis >= 20) return 'info';
+    return 'success';
   }
 
   private async copyLink(): Promise<void> {

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -327,6 +327,47 @@ export interface OpenClawRunSummary extends OpenClawSessionSummary {
   status: string;
 }
 
+export type OpenClawUsageWindowKey = 'today' | '7d' | '30d' | 'all';
+
+export interface OpenClawUsageTotals {
+  calls: number;
+  costAvailableCalls: number;
+  totalCostUsd: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+}
+
+export interface OpenClawUsageModel extends OpenClawUsageTotals {
+  model: string;
+  lastSeenAt: number | null;
+}
+
+export interface OpenClawUsageDay extends OpenClawUsageTotals {
+  date: string;
+}
+
+export interface OpenClawUsageWindow extends OpenClawUsageTotals {
+  key: OpenClawUsageWindowKey;
+  label: string;
+  startAt: number | null;
+  endAt: number;
+  models: OpenClawUsageModel[];
+  daily: OpenClawUsageDay[];
+}
+
+export interface OpenClawUsageAnalytics {
+  generatedAt: number;
+  filesScanned: number;
+  usageEvents: number;
+  duplicateEvents: number;
+  firstSeenAt: number | null;
+  lastSeenAt: number | null;
+  windows: Record<OpenClawUsageWindowKey, OpenClawUsageWindow>;
+}
+
 export interface OpenClawLogEntry {
   timestamp: number;
   seenAt: string;
@@ -368,6 +409,7 @@ export interface OpenClawResponse extends ApiEnvelope {
   channelSummary?: string[];
   activeSessions: OpenClawSessionSummary[];
   recentRuns: OpenClawRunSummary[];
+  usageAnalytics: OpenClawUsageAnalytics;
   logsTail: OpenClawLogEntry[];
   errorFeed: OpenClawErrorGroup[];
   logsError?: string | null;

--- a/server.js
+++ b/server.js
@@ -643,6 +643,7 @@ const OPENCLAW_LOG_TIMEOUT_MS = 10000;
 const OPENCLAW_ERROR_FEED_LIMIT = 12;
 const OPENCLAW_ERROR_OCCURRENCES_LIMIT = 3;
 const OPENCLAW_ERROR_WINDOW_MS = 24 * 60 * 60 * 1000;
+const OPENCLAW_USAGE_WINDOW_KEYS = ['today', '7d', '30d', 'all'];
 
 const OPENCLAW_UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
 const OPENCLAW_ID_TOKEN_RE = /\b(?:id|session|task|job|trace|request|pid|diagId|sessionKey|lane)[:=]?\s*[^\s,]+/gi;
@@ -651,6 +652,8 @@ const OPENCLAW_PATH_RE = /\/(?:home|tmp)\/[^\s]+/g;
 const OPENCLAW_AGENT_KEY_RE = /agent:[^\s]+/gi;
 const OPENCLAW_NUMERIC_RE = /\b\d+\b/g;
 const OPENCLAW_TIMESTAMP_RE = /\b\d{4}-\d{2}-\d{2}[t\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:z|[+\-]\d{2}:\d{2})?\b/gi;
+
+const openClawUsageFileCache = new Map();
 
 function readJsonFileSafe(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -725,6 +728,383 @@ function readSessionDurationSec(sessionFile, entry = {}) {
   } catch {
     return null;
   }
+}
+
+function openClawUsageRootSessionId(filePath) {
+  const name = path.basename(filePath);
+  const deletedIndex = name.indexOf('.jsonl.deleted.');
+  if (deletedIndex >= 0) {
+    return name.slice(0, deletedIndex);
+  }
+
+  const withoutSuffix = name.endsWith('.jsonl') ? name.slice(0, -6) : name;
+  const checkpointIndex = withoutSuffix.indexOf('.checkpoint.');
+  return checkpointIndex >= 0 ? withoutSuffix.slice(0, checkpointIndex) : withoutSuffix;
+}
+
+function openClawUsageNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function openClawUsageCost(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(0, numeric) : null;
+}
+
+function openClawUsageModel(provider, model) {
+  if (!model) return 'unknown';
+  if (String(model).includes('/')) return String(model);
+  return provider ? `${provider}/${model}` : String(model);
+}
+
+function openClawStartOfDay(timestamp = Date.now()) {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+function openClawWindowStart(days, now = Date.now()) {
+  if (!days) return null;
+  const start = new Date(openClawStartOfDay(now));
+  start.setDate(start.getDate() - (days - 1));
+  return start.getTime();
+}
+
+function openClawUsageDateKey(timestamp) {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function createOpenClawUsageAccumulator(key, label, startAt, endAt) {
+  return {
+    key,
+    label,
+    startAt,
+    endAt,
+    calls: 0,
+    costAvailableCalls: 0,
+    totalCostUsd: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    models: new Map(),
+    daily: new Map(),
+  };
+}
+
+function addOpenClawUsageToAccumulator(bucket, event, modelKey) {
+  bucket.calls += 1;
+  bucket.inputTokens += event.inputTokens;
+  bucket.outputTokens += event.outputTokens;
+  bucket.cacheReadTokens += event.cacheReadTokens;
+  bucket.cacheWriteTokens += event.cacheWriteTokens;
+  bucket.totalTokens += event.totalTokens;
+
+  if (event.totalCostUsd !== null) {
+    bucket.costAvailableCalls += 1;
+    bucket.totalCostUsd += event.totalCostUsd;
+  }
+
+  if (!modelKey) return;
+
+  const existingModel = bucket.models.get(modelKey) || {
+    model: modelKey,
+    calls: 0,
+    costAvailableCalls: 0,
+    totalCostUsd: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    lastSeenAt: null,
+  };
+
+  existingModel.calls += 1;
+  existingModel.inputTokens += event.inputTokens;
+  existingModel.outputTokens += event.outputTokens;
+  existingModel.cacheReadTokens += event.cacheReadTokens;
+  existingModel.cacheWriteTokens += event.cacheWriteTokens;
+  existingModel.totalTokens += event.totalTokens;
+  existingModel.lastSeenAt = existingModel.lastSeenAt === null ? event.timestamp : Math.max(existingModel.lastSeenAt, event.timestamp);
+
+  if (event.totalCostUsd !== null) {
+    existingModel.costAvailableCalls += 1;
+    existingModel.totalCostUsd += event.totalCostUsd;
+  }
+
+  bucket.models.set(modelKey, existingModel);
+
+  const dayKey = openClawUsageDateKey(event.timestamp);
+  const existingDay = bucket.daily.get(dayKey) || {
+    date: dayKey,
+    calls: 0,
+    costAvailableCalls: 0,
+    totalCostUsd: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+  };
+
+  existingDay.calls += 1;
+  existingDay.inputTokens += event.inputTokens;
+  existingDay.outputTokens += event.outputTokens;
+  existingDay.cacheReadTokens += event.cacheReadTokens;
+  existingDay.cacheWriteTokens += event.cacheWriteTokens;
+  existingDay.totalTokens += event.totalTokens;
+
+  if (event.totalCostUsd !== null) {
+    existingDay.costAvailableCalls += 1;
+    existingDay.totalCostUsd += event.totalCostUsd;
+  }
+
+  bucket.daily.set(dayKey, existingDay);
+}
+
+function finalizeOpenClawUsageAccumulator(bucket) {
+  const models = [...bucket.models.values()]
+    .map(model => ({
+      ...model,
+      totalCostUsd: model.costAvailableCalls ? Number(model.totalCostUsd.toFixed(6)) : null,
+    }))
+    .sort((a, b) => {
+      const costA = a.totalCostUsd ?? -1;
+      const costB = b.totalCostUsd ?? -1;
+      if (costB !== costA) return costB - costA;
+      if (b.totalTokens !== a.totalTokens) return b.totalTokens - a.totalTokens;
+      return a.model.localeCompare(b.model);
+    });
+
+  const daily = [...bucket.daily.values()]
+    .map(day => ({
+      ...day,
+      totalCostUsd: day.costAvailableCalls ? Number(day.totalCostUsd.toFixed(6)) : null,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    key: bucket.key,
+    label: bucket.label,
+    startAt: bucket.startAt,
+    endAt: bucket.endAt,
+    calls: bucket.calls,
+    costAvailableCalls: bucket.costAvailableCalls,
+    totalCostUsd: bucket.costAvailableCalls ? Number(bucket.totalCostUsd.toFixed(6)) : null,
+    inputTokens: bucket.inputTokens,
+    outputTokens: bucket.outputTokens,
+    cacheReadTokens: bucket.cacheReadTokens,
+    cacheWriteTokens: bucket.cacheWriteTokens,
+    totalTokens: bucket.totalTokens,
+    models,
+    daily,
+  };
+}
+
+function emptyOpenClawUsageAnalytics(now = Date.now()) {
+  const windowLabels = {
+    today: 'Today',
+    '7d': '7d',
+    '30d': '30d',
+    all: 'All time',
+  };
+  const windowStarts = {
+    today: openClawWindowStart(1, now),
+    '7d': openClawWindowStart(7, now),
+    '30d': openClawWindowStart(30, now),
+    all: null,
+  };
+
+  return {
+    generatedAt: now,
+    filesScanned: 0,
+    usageEvents: 0,
+    duplicateEvents: 0,
+    firstSeenAt: null,
+    lastSeenAt: null,
+    windows: Object.fromEntries(OPENCLAW_USAGE_WINDOW_KEYS.map(key => [key, finalizeOpenClawUsageAccumulator(createOpenClawUsageAccumulator(key, windowLabels[key], windowStarts[key], now))])),
+  };
+}
+
+function listOpenClawUsageFiles() {
+  const files = [];
+  if (!OPENCLAW_AGENTS_DIR || !fs.existsSync(OPENCLAW_AGENTS_DIR)) {
+    return files;
+  }
+
+  for (const agentName of fs.readdirSync(OPENCLAW_AGENTS_DIR)) {
+    const sessionsDir = path.join(OPENCLAW_AGENTS_DIR, agentName, 'sessions');
+    if (!fs.existsSync(sessionsDir)) continue;
+
+    for (const name of fs.readdirSync(sessionsDir)) {
+      if (name.endsWith('.lock')) continue;
+      if (name.endsWith('.jsonl') || name.includes('.jsonl.deleted.')) {
+        files.push(path.join(sessionsDir, name));
+      }
+    }
+  }
+
+  return files.sort();
+}
+
+function parseOpenClawUsageFile(filePath, stats) {
+  const events = [];
+  const rootSessionId = openClawUsageRootSessionId(filePath);
+  const lines = fs.readFileSync(filePath, 'utf8').split('\n').filter(Boolean);
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      const message = parsed?.message;
+      if (!message || message.role !== 'assistant' || !message.usage) continue;
+
+      const usage = message.usage || {};
+      const totalTokens = openClawUsageNumber(usage.totalTokens, 0);
+      if (totalTokens <= 0) continue;
+
+      const model = openClawUsageModel(message.provider, message.model);
+      if (!model || model.includes('delivery-mirror')) continue;
+
+      const inputTokens = openClawUsageNumber(usage.input, 0);
+      const outputTokens = openClawUsageNumber(usage.output, 0);
+      const cacheReadTokens = openClawUsageNumber(usage.cacheRead, 0);
+      const cacheWriteTokens = openClawUsageNumber(usage.cacheWrite, 0);
+      const cost = usage.cost || {};
+      const costInputUsd = openClawUsageCost(cost.input);
+      const costOutputUsd = openClawUsageCost(cost.output);
+      const costCacheReadUsd = openClawUsageCost(cost.cacheRead);
+      const costCacheWriteUsd = openClawUsageCost(cost.cacheWrite);
+      let totalCostUsd = openClawUsageCost(cost.total);
+
+      if (totalCostUsd === null) {
+        const components = [costInputUsd, costOutputUsd, costCacheReadUsd, costCacheWriteUsd].filter(value => value !== null);
+        if (components.length) {
+          totalCostUsd = components.reduce((sum, value) => sum + value, 0);
+        }
+      }
+
+      let timestamp = Date.parse(parsed.timestamp || '');
+      if (Number.isNaN(timestamp)) {
+        timestamp = openClawUsageNumber(message.timestamp, 0);
+      }
+      if (!timestamp) continue;
+
+      const responseId = String(message.responseId || parsed.id || '').trim();
+      const eventKey = responseId
+        ? `resp:${responseId}`
+        : `${rootSessionId}:${timestamp}:${model}:${inputTokens}:${outputTokens}:${cacheReadTokens}:${cacheWriteTokens}:${totalTokens}`;
+
+      events.push({
+        key: eventKey,
+        sessionId: rootSessionId,
+        timestamp,
+        model,
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        totalTokens,
+        totalCostUsd,
+      });
+    } catch {
+      // ignore malformed lines
+    }
+  }
+
+  return {
+    size: stats.size,
+    mtimeMs: stats.mtimeMs,
+    events,
+  };
+}
+
+function readOpenClawUsageAnalytics() {
+  const now = Date.now();
+  const files = listOpenClawUsageFiles();
+  const livePaths = new Set(files);
+
+  for (const cachedPath of [...openClawUsageFileCache.keys()]) {
+    if (!livePaths.has(cachedPath)) {
+      openClawUsageFileCache.delete(cachedPath);
+    }
+  }
+
+  const allEvents = [];
+
+  for (const filePath of files) {
+    let stats;
+    try {
+      stats = fs.statSync(filePath);
+    } catch {
+      openClawUsageFileCache.delete(filePath);
+      continue;
+    }
+
+    const cached = openClawUsageFileCache.get(filePath);
+    const unchanged = cached && cached.size === stats.size && cached.mtimeMs === stats.mtimeMs;
+    const summary = unchanged ? cached : parseOpenClawUsageFile(filePath, stats);
+    summary.size = stats.size;
+    summary.mtimeMs = stats.mtimeMs;
+    openClawUsageFileCache.set(filePath, summary);
+    allEvents.push(...summary.events);
+  }
+
+  const windows = {
+    today: createOpenClawUsageAccumulator('today', 'Today', openClawWindowStart(1, now), now),
+    '7d': createOpenClawUsageAccumulator('7d', '7d', openClawWindowStart(7, now), now),
+    '30d': createOpenClawUsageAccumulator('30d', '30d', openClawWindowStart(30, now), now),
+    all: createOpenClawUsageAccumulator('all', 'All time', null, now),
+  };
+
+  const seenKeys = new Set();
+  let duplicateEvents = 0;
+  let firstSeenAt = null;
+  let lastSeenAt = null;
+
+  allEvents.sort((a, b) => a.timestamp - b.timestamp);
+
+  for (const event of allEvents) {
+    if (!event || !event.key) continue;
+    if (seenKeys.has(event.key)) {
+      duplicateEvents += 1;
+      continue;
+    }
+    seenKeys.add(event.key);
+
+    firstSeenAt = firstSeenAt === null ? event.timestamp : Math.min(firstSeenAt, event.timestamp);
+    lastSeenAt = lastSeenAt === null ? event.timestamp : Math.max(lastSeenAt, event.timestamp);
+
+    addOpenClawUsageToAccumulator(windows.all, event, event.model);
+
+    if (windows.today.startAt !== null && event.timestamp >= windows.today.startAt) {
+      addOpenClawUsageToAccumulator(windows.today, event, event.model);
+    }
+
+    if (windows['7d'].startAt !== null && event.timestamp >= windows['7d'].startAt) {
+      addOpenClawUsageToAccumulator(windows['7d'], event, event.model);
+    }
+
+    if (windows['30d'].startAt !== null && event.timestamp >= windows['30d'].startAt) {
+      addOpenClawUsageToAccumulator(windows['30d'], event, event.model);
+    }
+  }
+
+  return {
+    generatedAt: now,
+    filesScanned: files.length,
+    usageEvents: seenKeys.size,
+    duplicateEvents,
+    firstSeenAt,
+    lastSeenAt,
+    windows: Object.fromEntries(OPENCLAW_USAGE_WINDOW_KEYS.map(key => [key, finalizeOpenClawUsageAccumulator(windows[key])])),
+  };
 }
 
 function collectOpenClawActivity() {
@@ -1000,6 +1380,12 @@ function fetchOpenClawRuntime() {
     const gatewayPid = status.gatewayService?.runtime?.pid;
     const gatewayProcess = readProcessSnapshot(gatewayPid);
     const activity = collectOpenClawActivity();
+    let usageAnalytics = emptyOpenClawUsageAnalytics(updatedAt);
+    try {
+      usageAnalytics = readOpenClawUsageAnalytics();
+    } catch (error) {
+      console.warn('[openclaw] usage analytics unavailable:', error.message);
+    }
     let logsTail = [];
     let errorFeed = [];
     let logsError = null;
@@ -1038,6 +1424,7 @@ function fetchOpenClawRuntime() {
       secretDiagnostics: status.secretDiagnostics || [],
       activeSessions: activity.activeSessions,
       recentRuns: activity.recentRuns,
+      usageAnalytics,
       logsTail,
       errorFeed,
       logsError,

--- a/test/api-smoke.test.js
+++ b/test/api-smoke.test.js
@@ -78,6 +78,20 @@ function createTestApp({ cacheOverrides = {}, sourceOverrides = {}, infraError =
       memoryPlugin: { enabled: true, slot: 'memory-core' },
       activeSessions: [{ key: 'agent:main:discord:direct:123', sessionId: 'sid-1', agent: 'main', type: 'direct', name: 'Tony DM', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 60000, active: true, percentUsed: 12, totalTokens: 3200, contextTokens: 272000, estimatedCostUsd: 0.01, chatType: 'direct', label: 'Tony DM', subject: null, spawnedBy: null, abortedLastRun: false }],
       recentRuns: [{ key: 'agent:main:cron:test:run:sid-2', sessionId: 'sid-2', agent: 'main', type: 'run', name: 'Daily Standup', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 120000, active: false, percentUsed: 8, totalTokens: 2800, contextTokens: 272000, estimatedCostUsd: 0.02, chatType: 'direct', label: 'Daily Standup', subject: null, spawnedBy: null, abortedLastRun: false, durationSec: 45, status: 'completed' }],
+      usageAnalytics: {
+        generatedAt: 1713124800000,
+        filesScanned: 3,
+        usageEvents: 12,
+        duplicateEvents: 1,
+        firstSeenAt: 1713038400000,
+        lastSeenAt: 1713124800000,
+        windows: {
+          today: { key: 'today', label: 'Today', startAt: 1713052800000, endAt: 1713124800000, calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1234, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400, models: [{ model: 'openai/gpt-5.4', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1234, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400, lastSeenAt: 1713124800000 }], daily: [{ date: '2026-04-15', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1234, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }] },
+          '7d': { key: '7d', label: '7d', startAt: 1712534400000, endAt: 1713124800000, calls: 8, costAvailableCalls: 8, totalCostUsd: 0.2345, inputTokens: 8000, outputTokens: 1200, cacheReadTokens: 1600, cacheWriteTokens: 0, totalTokens: 10800, models: [{ model: 'openai/gpt-5.4', calls: 8, costAvailableCalls: 8, totalCostUsd: 0.2345, inputTokens: 8000, outputTokens: 1200, cacheReadTokens: 1600, cacheWriteTokens: 0, totalTokens: 10800, lastSeenAt: 1713124800000 }], daily: [{ date: '2026-04-14', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1111, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }, { date: '2026-04-15', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1234, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }] },
+          '30d': { key: '30d', label: '30d', startAt: 1710547200000, endAt: 1713124800000, calls: 12, costAvailableCalls: 12, totalCostUsd: 0.3456, inputTokens: 12000, outputTokens: 1800, cacheReadTokens: 2400, cacheWriteTokens: 0, totalTokens: 16200, models: [{ model: 'openai/gpt-5.4', calls: 12, costAvailableCalls: 12, totalCostUsd: 0.3456, inputTokens: 12000, outputTokens: 1800, cacheReadTokens: 2400, cacheWriteTokens: 0, totalTokens: 16200, lastSeenAt: 1713124800000 }], daily: [{ date: '2026-04-01', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1111, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }, { date: '2026-04-14', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1111, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }, { date: '2026-04-15', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1234, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }] },
+          all: { key: 'all', label: 'All time', startAt: null, endAt: 1713124800000, calls: 12, costAvailableCalls: 12, totalCostUsd: 0.3456, inputTokens: 12000, outputTokens: 1800, cacheReadTokens: 2400, cacheWriteTokens: 0, totalTokens: 16200, models: [{ model: 'openai/gpt-5.4', calls: 12, costAvailableCalls: 12, totalCostUsd: 0.3456, inputTokens: 12000, outputTokens: 1800, cacheReadTokens: 2400, cacheWriteTokens: 0, totalTokens: 16200, lastSeenAt: 1713124800000 }], daily: [{ date: '2026-04-01', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1111, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }, { date: '2026-04-14', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1111, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }, { date: '2026-04-15', calls: 4, costAvailableCalls: 4, totalCostUsd: 0.1234, inputTokens: 4000, outputTokens: 600, cacheReadTokens: 800, cacheWriteTokens: 0, totalTokens: 5400 }] },
+        },
+      },
       logsTail: [{ timestamp: 1713124800000, seenAt: '2026-04-15T12:00:00Z', level: 'error', source: 'tools', message: '[tools] read failed: ENOENT' }],
       errorFeed: [{ signature: 'tools|enoent', source: 'tools', severity: 'error', count: 2, firstSeen: 1713124700000, lastSeen: 1713124800000, sampleMessage: '[tools] read failed: ENOENT', lastOccurrences: [{ timestamp: 1713124800000, source: 'tools', level: 'error', message: '[tools] read failed: ENOENT' }] }],
       logsError: null,
@@ -153,6 +167,8 @@ test('main API routes return smoke-level shapes', async () => {
       assert.equal(openClaw.agents.totalSessions, 16);
       assert.equal(openClaw.activeSessions.length, 1);
       assert.equal(openClaw.recentRuns.length, 1);
+      assert.equal(openClaw.usageAnalytics.windows.today.calls, 4);
+      assert.equal(openClaw.usageAnalytics.windows.all.totalCostUsd, 0.3456);
       assert.equal(openClaw.logsTail.length, 1);
       assert.equal(openClaw.errorFeed.length, 1);
     });


### PR DESCRIPTION
## Summary
- add OpenClaw token and cost analytics to the existing /api/openclaw payload
- aggregate real transcript usage into today / 7d / 30d / all-time windows with per-model and daily breakdowns
- surface the analytics in the OpenClaw dashboard view and Home summary

## What changed
- parse assistant usage records from real OpenClaw session transcripts under ~/.openclaw/agents/*/sessions/*.jsonl
- dedupe repeated checkpoint entries using response ids when available, with a stable fallback signature for older entries
- expose usageAnalytics with input, output, cache read, cache write, total tokens, call counts, cost coverage, spend totals, model rollups, and daily trend data
- add dashboard cards, model breakdowns, and a daily spend trend for the selected window
- include today\'s OpenClaw spend in the Home summary when available

## Verification
- node --check server.js
- npm test
- npm --prefix frontend run build
- live isolated /api/openclaw check on 127.0.0.1:4551

Closes #51