### PR TITLE
Polish Home reminders spacing and padding

### DIFF
--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -100,7 +100,7 @@ interface PinnedHomeItem {
         </section>
       </cc-card>
 
-      <article class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
+      <article class="cc-panel rounded-[28px] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">Reminders</p>

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -100,7 +100,7 @@ interface PinnedHomeItem {
         </section>
       </cc-card>
 
-      <article class="cc-panel mt-2 rounded-[28px] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
+      <article class="cc-panel mt-3 rounded-[28px] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">Reminders</p>

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -100,15 +100,17 @@ interface PinnedHomeItem {
         </section>
       </cc-card>
 
-      <cc-card eyebrow="Reminders" title="Keep the little stuff visible" [compact]="true">
-        <div class="space-y-5">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <p class="text-sm text-[var(--cc-text-muted)]">Quick capture for things you do not want falling through the cracks.</p>
-            </div>
-            <button type="button" (click)="openReminderComposer()" class="cc-action-button">＋ Add</button>
+      <article class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-6 md:p-7">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">Reminders</p>
+            <h2 class="mt-3 text-[1.6rem] font-semibold tracking-tight text-[var(--cc-text)]">Keep the little stuff visible</h2>
+            <p class="mt-3 text-sm leading-7 text-[var(--cc-text-muted)]">Quick capture for things you do not want falling through the cracks.</p>
           </div>
+          <button type="button" (click)="openReminderComposer()" class="cc-action-button">＋ Add</button>
+        </div>
 
+        <div class="mt-5 space-y-5">
           @if (composerOpen()) {
             <div class="cc-list-card grid gap-3 p-4 md:grid-cols-[1fr_180px_auto_auto]">
               <input [value]="reminderText()" (input)="reminderText.set($any($event.target).value)" (keydown)="onReminderKeydown($event)" class="cc-input rounded-xl px-4 py-3 text-sm" placeholder="What do you need to remember?" />
@@ -118,7 +120,7 @@ interface PinnedHomeItem {
             </div>
           }
 
-          <div class="space-y-3 py-2">
+          <div class="space-y-3">
             @if (!reminders.items().length) {
               <cc-state-panel kind="empty" title="No reminders yet" message="Add one above, or press N while on Home to capture a quick reminder."></cc-state-panel>
             } @else {
@@ -138,7 +140,7 @@ interface PinnedHomeItem {
             }
           </div>
         </div>
-      </cc-card>
+      </article>
 
       <section class="grid gap-6" [class.lg:grid-cols-3]="!homeLayout.layout().compact" [class.lg:grid-cols-2]="homeLayout.layout().compact">
         @for (sectionId of homeLayout.layout().order; track sectionId; let index = $index) {

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -118,7 +118,7 @@ interface PinnedHomeItem {
             </div>
           }
 
-          <div class="space-y-3">
+          <div class="space-y-3 py-2">
             @if (!reminders.items().length) {
               <cc-state-panel kind="empty" title="No reminders yet" message="Add one above, or press N while on Home to capture a quick reminder."></cc-state-panel>
             } @else {

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -100,7 +100,7 @@ interface PinnedHomeItem {
         </section>
       </cc-card>
 
-      <article class="cc-panel mt-3 rounded-[28px] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
+      <article class="cc-panel mt-4 rounded-[28px] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">Reminders</p>

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -100,7 +100,7 @@ interface PinnedHomeItem {
         </section>
       </cc-card>
 
-      <article class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] p-6 md:p-7">
+      <article class="rounded-3xl border border-[var(--cc-border)] bg-[var(--cc-surface)] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">Reminders</p>
@@ -110,7 +110,7 @@ interface PinnedHomeItem {
           <button type="button" (click)="openReminderComposer()" class="cc-action-button">＋ Add</button>
         </div>
 
-        <div class="mt-6 space-y-5">
+        <div class="mt-5 space-y-5">
           @if (composerOpen()) {
             <div class="cc-list-card grid gap-3 p-4 md:grid-cols-[1fr_180px_auto_auto]">
               <input [value]="reminderText()" (input)="reminderText.set($any($event.target).value)" (keydown)="onReminderKeydown($event)" class="cc-input rounded-xl px-4 py-3 text-sm" placeholder="What do you need to remember?" />

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -100,7 +100,7 @@ interface PinnedHomeItem {
         </section>
       </cc-card>
 
-      <article class="cc-panel rounded-[28px] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
+      <article class="cc-panel mt-2 rounded-[28px] px-6 pb-6 pt-7 md:px-7 md:pb-7 md:pt-8">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-[var(--cc-text-soft)]">Reminders</p>

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -120,7 +120,7 @@ interface PinnedHomeItem {
             </div>
           }
 
-          <div class="space-y-3">
+          <div class="space-y-3 pt-4">
             @if (!reminders.items().length) {
               <cc-state-panel kind="empty" title="No reminders yet" message="Add one above, or press N while on Home to capture a quick reminder."></cc-state-panel>
             } @else {

--- a/frontend/src/app/features/home/home.page.ts
+++ b/frontend/src/app/features/home/home.page.ts
@@ -110,7 +110,7 @@ interface PinnedHomeItem {
           <button type="button" (click)="openReminderComposer()" class="cc-action-button">＋ Add</button>
         </div>
 
-        <div class="mt-5 space-y-5">
+        <div class="mt-6 space-y-5">
           @if (composerOpen()) {
             <div class="cc-list-card grid gap-3 p-4 md:grid-cols-[1fr_180px_auto_auto]">
               <input [value]="reminderText()" (input)="reminderText.set($any($event.target).value)" (keydown)="onReminderKeydown($event)" class="cc-input rounded-xl px-4 py-3 text-sm" placeholder="What do you need to remember?" />


### PR DESCRIPTION
## Summary
- align the Reminders panel shell with the rest of Home
- add visible breathing room above the reminders state block
- increase the section gap between Today and Reminders so it matches the surrounding page rhythm better

## Verification
- npm test
- npm --prefix frontend run build
- curl checks for http://127.0.0.1:4500 and http://127.0.0.1:4200
