### PR TITLE
Fix OpenClaw live session rendering in worker views

### DIFF
--- a/frontend/src/app/features/openclaw/openclaw.page.ts
+++ b/frontend/src/app/features/openclaw/openclaw.page.ts
@@ -343,11 +343,11 @@ import { TrendBarsComponent } from '../../shared/ui/trend-bars.component';
               <cc-pill tone="info">{{ activeSessionCount() }} live</cc-pill>
             </div>
 
-            @if (!openClaw.data()!.activeSessions.length) {
-              <cc-state-panel class="mt-5" kind="empty" title="No recent sessions" message="No OpenClaw sessions were active in the recent window."></cc-state-panel>
+            @if (!liveSessions().length) {
+              <cc-state-panel class="mt-5" kind="empty" title="No live sessions" message="No OpenClaw sessions are currently active."></cc-state-panel>
             } @else {
               <div class="mt-5 space-y-3">
-                @for (session of openClaw.data()!.activeSessions; track session.key) {
+                @for (session of liveSessions(); track session.key) {
                   <div class="cc-stat-surface p-4">
                     <div class="flex flex-wrap items-start justify-between gap-3">
                       <div>
@@ -397,7 +397,7 @@ import { TrendBarsComponent } from '../../shared/ui/trend-bars.component';
                       </div>
                     </div>
                     <dl class="mt-4 grid gap-3 text-sm text-[var(--cc-text-muted)] md:grid-cols-4">
-                      <div><dt class="text-[var(--cc-text-soft)]">Finished</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatAge(run.ageMs) }}</dd></div>
+                      <div><dt class="text-[var(--cc-text-soft)]">Last seen</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatAge(run.ageMs) }}</dd></div>
                       <div><dt class="text-[var(--cc-text-soft)]">Duration</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatDuration(run.durationSec) }}</dd></div>
                       <div><dt class="text-[var(--cc-text-soft)]">Tokens</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ run.totalTokens }}</dd></div>
                       <div><dt class="text-[var(--cc-text-soft)]">Cost</dt><dd class="mt-1 font-medium text-[var(--cc-text)]">{{ formatCost(run.estimatedCostUsd) }}</dd></div>
@@ -450,7 +450,8 @@ export class OpenClawPage {
     const current = this.currentVersion();
     return Boolean(latest && current && latest !== current);
   });
-  protected readonly activeSessionCount = computed(() => (this.openClaw.data()?.activeSessions ?? []).filter((session) => session.active).length);
+  protected readonly liveSessions = computed(() => (this.openClaw.data()?.activeSessions ?? []).filter((session) => session.active));
+  protected readonly activeSessionCount = computed(() => this.liveSessions().length);
   protected readonly errorFeedCount = computed(() => this.openClaw.data()?.errorFeed?.length || 0);
   protected readonly selectedUsageWindowData = computed<OpenClawUsageWindow | null>(() => this.openClaw.data()?.usageAnalytics?.windows?.[this.selectedUsageWindow()] ?? null);
   protected readonly selectedUsageModels = computed<OpenClawUsageModel[]>(() => (this.selectedUsageWindowData()?.models ?? []).slice(0, 8));

--- a/frontend/src/app/features/sub-agents/sub-agents.page.ts
+++ b/frontend/src/app/features/sub-agents/sub-agents.page.ts
@@ -202,7 +202,7 @@ export class SubAgentsPage {
     const activeSessions = data?.activeSessions ?? [];
     const recentRuns = data?.recentRuns ?? [];
 
-    const matchedActive = activeSessions.find((session) => this.matchTerm(session, agent.bindingTerms));
+    const matchedActive = activeSessions.find((session) => session.active && this.matchTerm(session, agent.bindingTerms));
     if (matchedActive) {
       return {
         state: 'active',

--- a/test/api-smoke.test.js
+++ b/test/api-smoke.test.js
@@ -76,7 +76,10 @@ function createTestApp({ cacheOverrides = {}, sourceOverrides = {}, infraError =
       nodeService: { label: 'systemd', installed: false, loaded: false, managedByOpenClaw: false, externallyManaged: false, runtime: { status: 'stopped', state: 'inactive' }, runtimeShort: 'stopped (state inactive)' },
       agents: { defaultId: 'main', agents: [{ id: 'main', name: 'main', workspaceDir: '/tmp/workspace', bootstrapPending: false, sessionsPath: '/tmp/sessions.json', sessionsCount: 16 }], totalSessions: 16, bootstrapPendingCount: 0 },
       memoryPlugin: { enabled: true, slot: 'memory-core' },
-      activeSessions: [{ key: 'agent:main:discord:direct:123', sessionId: 'sid-1', agent: 'main', type: 'direct', name: 'Tony DM', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 60000, active: true, percentUsed: 12, totalTokens: 3200, contextTokens: 272000, estimatedCostUsd: 0.01, chatType: 'direct', label: 'Tony DM', subject: null, spawnedBy: null, abortedLastRun: false }],
+      activeSessions: [
+        { key: 'agent:main:discord:direct:123', sessionId: 'sid-1', agent: 'main', type: 'direct', name: 'Tony DM', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 60000, active: true, percentUsed: 12, totalTokens: 3200, contextTokens: 272000, estimatedCostUsd: 0.01, chatType: 'direct', label: 'Tony DM', subject: null, spawnedBy: null, abortedLastRun: false },
+        { key: 'agent:main:discord:direct:456', sessionId: 'sid-3', agent: 'main', type: 'direct', name: 'Idle Thread', model: 'gpt-5.4', updatedAt: 1713124740000, ageMs: 120000, active: false, percentUsed: 4, totalTokens: 900, contextTokens: 272000, estimatedCostUsd: 0.003, chatType: 'direct', label: 'Idle Thread', subject: null, spawnedBy: null, abortedLastRun: false },
+      ],
       recentRuns: [{ key: 'agent:main:cron:test:run:sid-2', sessionId: 'sid-2', agent: 'main', type: 'run', name: 'Daily Standup', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 120000, active: false, percentUsed: 8, totalTokens: 2800, contextTokens: 272000, estimatedCostUsd: 0.02, chatType: 'direct', label: 'Daily Standup', subject: null, spawnedBy: null, abortedLastRun: false, durationSec: 45, status: 'completed' }],
       usageAnalytics: {
         generatedAt: 1713124800000,
@@ -165,7 +168,9 @@ test('main API routes return smoke-level shapes', async () => {
       assert.equal(openClaw.ok, true);
       assert.equal(openClaw.gateway.reachable, true);
       assert.equal(openClaw.agents.totalSessions, 16);
-      assert.equal(openClaw.activeSessions.length, 1);
+      assert.equal(openClaw.activeSessions.length, 2);
+      assert.equal(openClaw.activeSessions[0].active, true);
+      assert.equal(openClaw.activeSessions[1].active, false);
       assert.equal(openClaw.recentRuns.length, 1);
       assert.equal(openClaw.usageAnalytics.windows.today.calls, 4);
       assert.equal(openClaw.usageAnalytics.windows.all.totalCostUsd, 0.3456);


### PR DESCRIPTION
## Summary
- render the OpenClaw Active sessions panel from live sessions only
- prevent Sub-agents from promoting idle matched sessions to active
- update the Recent runs age label and empty-state copy to match live-session semantics

## Testing
- npm test
- npm --prefix frontend run build

## Notes
- implemented via the new worker roster flow: Scout mapped, Scope bounded, Patch edited, Proof verified