### PR TITLE
Show configured model pills in the Sub-agents view

### DIFF
--- a/frontend/src/app/core/data/dashboard-data.service.ts
+++ b/frontend/src/app/core/data/dashboard-data.service.ts
@@ -48,6 +48,7 @@ export class DashboardDataService {
     channelSummary: OpenClawResponse['channelSummary'];
     activeSessions: OpenClawResponse['activeSessions'];
     recentRuns: OpenClawResponse['recentRuns'];
+    configuredAgents: OpenClawResponse['configuredAgents'];
     usageAnalytics: OpenClawResponse['usageAnalytics'];
     logsTail: OpenClawResponse['logsTail'];
     errorFeed: OpenClawResponse['errorFeed'];
@@ -167,6 +168,7 @@ export class DashboardDataService {
     channelSummary: OpenClawResponse['channelSummary'];
     activeSessions: OpenClawResponse['activeSessions'];
     recentRuns: OpenClawResponse['recentRuns'];
+    configuredAgents: OpenClawResponse['configuredAgents'];
     usageAnalytics: OpenClawResponse['usageAnalytics'];
     logsTail: OpenClawResponse['logsTail'];
     errorFeed: OpenClawResponse['errorFeed'];
@@ -194,6 +196,7 @@ export class DashboardDataService {
         channelSummary: response.channelSummary,
         activeSessions: response.activeSessions,
         recentRuns: response.recentRuns,
+        configuredAgents: response.configuredAgents,
         usageAnalytics: response.usageAnalytics,
         logsTail: response.logsTail,
         errorFeed: response.errorFeed,

--- a/frontend/src/app/features/sub-agents/sub-agents.page.ts
+++ b/frontend/src/app/features/sub-agents/sub-agents.page.ts
@@ -42,7 +42,10 @@ interface SubAgentRuntimeStatus {
                   <div class="text-lg font-semibold text-[var(--cc-text)]">{{ agent.name }}</div>
                   <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ agent.role }}</div>
                 </div>
-                <cc-pill [tone]="statusTone(runtime.state)">{{ statusLabel(runtime.state) }}</cc-pill>
+                <div class="flex flex-wrap items-center justify-end gap-2">
+                  <cc-pill [tone]="configuredModelTone(agent.id)">{{ configuredModelLabel(agent.id) }}</cc-pill>
+                  <cc-pill [tone]="statusTone(runtime.state)">{{ statusLabel(runtime.state) }}</cc-pill>
+                </div>
               </div>
               <div class="mt-4 text-sm leading-6 text-[var(--cc-text-muted)]">{{ agent.spawnWhen }}</div>
               <div class="mt-4 rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-soft)] px-4 py-3 text-xs leading-5 text-[var(--cc-text-soft)]">
@@ -63,7 +66,10 @@ interface SubAgentRuntimeStatus {
                 <div class="mt-2 text-2xl font-semibold text-[var(--cc-text)]">{{ agent.name }}</div>
                 <div class="mt-2 text-sm text-[var(--cc-text-muted)]">{{ agent.role }}</div>
               </div>
-              <cc-pill [tone]="statusTone(runtime.state)">{{ statusLabel(runtime.state) }}</cc-pill>
+              <div class="flex flex-wrap items-center justify-end gap-2">
+                <cc-pill [tone]="configuredModelTone(agent.id)">{{ configuredModelLabel(agent.id) }}</cc-pill>
+                <cc-pill [tone]="statusTone(runtime.state)">{{ statusLabel(runtime.state) }}</cc-pill>
+              </div>
             </div>
 
             <div class="mt-5 rounded-2xl border border-[var(--cc-border)] bg-[var(--cc-surface-soft)] px-4 py-3 text-sm leading-7 text-[var(--cc-text-muted)]">
@@ -219,6 +225,21 @@ export class SubAgentsPage {
     }
 
     return 'No active or recent OpenClaw session currently matches this role. It remains available as part of the standing roster.';
+  }
+
+  protected configuredModelLabel(agentId: SubAgentId): string {
+    const model = this.openClaw.data()?.configuredAgents?.find((entry) => entry.id === agentId)?.model;
+    if (!model) return 'model unknown';
+    const [provider, ...rest] = model.split('/');
+    const modelId = rest.join('/') || provider;
+    return `${provider} · ${modelId}`;
+  }
+
+  protected configuredModelTone(agentId: SubAgentId): 'accent' | 'info' | 'neutral' {
+    const model = this.openClaw.data()?.configuredAgents?.find((entry) => entry.id === agentId)?.model || '';
+    if (model.startsWith('ollama/')) return 'info';
+    if (model.startsWith('openai/')) return 'accent';
+    return 'neutral';
   }
 
   protected usageSummary(agentId: SubAgentId, window: OpenClawUsageWindowKey): string {

--- a/frontend/src/app/models/api.ts
+++ b/frontend/src/app/models/api.ts
@@ -375,6 +375,12 @@ export interface OpenClawUsageAnalytics {
   windows: Record<OpenClawUsageWindowKey, OpenClawUsageWindow>;
 }
 
+export interface OpenClawConfiguredAgent {
+  id: string;
+  name: string;
+  model: string | null;
+}
+
 export interface OpenClawLogEntry {
   timestamp: number;
   seenAt: string;
@@ -416,6 +422,7 @@ export interface OpenClawResponse extends ApiEnvelope {
   channelSummary?: string[];
   activeSessions: OpenClawSessionSummary[];
   recentRuns: OpenClawRunSummary[];
+  configuredAgents?: OpenClawConfiguredAgent[];
   usageAnalytics: OpenClawUsageAnalytics;
   logsTail: OpenClawLogEntry[];
   errorFeed: OpenClawErrorGroup[];

--- a/server.js
+++ b/server.js
@@ -1465,6 +1465,22 @@ function buildOpenClawErrorFeed(...collections) {
     .slice(0, OPENCLAW_ERROR_FEED_LIMIT);
 }
 
+function readOpenClawConfiguredAgents() {
+  const raw = execFileSync('openclaw', ['agents', 'list', '--json'], {
+    encoding: 'utf8',
+    timeout: 15000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  const list = JSON.parse(raw);
+  return Array.isArray(list)
+    ? list.map((agent) => ({
+        id: agent.id,
+        name: agent.identityName || agent.name || agent.id,
+        model: agent.model || null,
+      }))
+    : [];
+}
+
 function fetchOpenClawRuntime() {
   beginSource('openclaw');
   try {
@@ -1478,6 +1494,12 @@ function fetchOpenClawRuntime() {
     const gatewayPid = status.gatewayService?.runtime?.pid;
     const gatewayProcess = readProcessSnapshot(gatewayPid);
     const activity = collectOpenClawActivity();
+    let configuredAgents = [];
+    try {
+      configuredAgents = readOpenClawConfiguredAgents();
+    } catch (error) {
+      console.warn('[openclaw] configured agent roster unavailable:', error.message);
+    }
     let usageAnalytics = emptyOpenClawUsageAnalytics(updatedAt);
     try {
       usageAnalytics = readOpenClawUsageAnalytics();
@@ -1522,6 +1544,7 @@ function fetchOpenClawRuntime() {
       secretDiagnostics: status.secretDiagnostics || [],
       activeSessions: activity.activeSessions,
       recentRuns: activity.recentRuns,
+      configuredAgents,
       usageAnalytics,
       logsTail,
       errorFeed,

--- a/test/api-smoke.test.js
+++ b/test/api-smoke.test.js
@@ -81,6 +81,7 @@ function createTestApp({ cacheOverrides = {}, sourceOverrides = {}, infraError =
         { key: 'agent:main:discord:direct:456', sessionId: 'sid-3', agent: 'main', type: 'direct', name: 'Idle Thread', model: 'gpt-5.4', updatedAt: 1713124740000, ageMs: 120000, active: false, percentUsed: 4, totalTokens: 900, contextTokens: 272000, estimatedCostUsd: 0.003, chatType: 'direct', label: 'Idle Thread', subject: null, spawnedBy: null, abortedLastRun: false },
       ],
       recentRuns: [{ key: 'agent:main:cron:test:run:sid-2', sessionId: 'sid-2', agent: 'main', type: 'run', name: 'Daily Standup', model: 'gpt-5.4', updatedAt: 1713124800000, ageMs: 120000, active: false, percentUsed: 8, totalTokens: 2800, contextTokens: 272000, estimatedCostUsd: 0.02, chatType: 'direct', label: 'Daily Standup', subject: null, spawnedBy: null, abortedLastRun: false, durationSec: 45, status: 'completed' }],
+      configuredAgents: [{ id: 'scout', name: 'Scout', model: 'ollama/qwen3:14b' }, { id: 'patch', name: 'Patch', model: 'openai/gpt-5.4' }],
       usageAnalytics: {
         generatedAt: 1713124800000,
         filesScanned: 3,
@@ -172,6 +173,8 @@ test('main API routes return smoke-level shapes', async () => {
       assert.equal(openClaw.activeSessions[0].active, true);
       assert.equal(openClaw.activeSessions[1].active, false);
       assert.equal(openClaw.recentRuns.length, 1);
+      assert.equal(openClaw.configuredAgents.length, 2);
+      assert.equal(openClaw.configuredAgents[0].model, 'ollama/qwen3:14b');
       assert.equal(openClaw.usageAnalytics.windows.today.calls, 4);
       assert.equal(openClaw.usageAnalytics.windows.today.agents.length, 2);
       assert.equal(openClaw.usageAnalytics.windows.today.agents[0].agent, 'scout');


### PR DESCRIPTION
## Summary
- expose configured per-agent model metadata in `/api/openclaw` from the real OpenClaw agent roster
- render persistent configured-model pills in the Sub-agents cards and detail header
- keep the configured model distinct from live usage-derived model telemetry

## Testing
- npm test
- npm --prefix frontend run build
- verified live `/api/openclaw` returns `configuredAgents` locally
- verified `/sub-agents` serves successfully locally

Closes #112