### PR TITLE
docs: add installation and configuration guides

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,351 @@
+# Configuration
+
+This guide explains how `command-center` discovers config, which settings are required vs optional, and how local paths and environment variables are resolved.
+
+For installation steps, see [Installation.md](./Installation.md).
+For architecture, see [System-Design.md](./System-Design.md).
+
+---
+
+## 1. Config sources
+
+`command-center` uses a mix of:
+- JSON config files
+- environment variables
+
+### JSON config resolution order
+The loader checks, in order:
+1. `COMMAND_CENTER_CONFIG` if set
+2. `config.local.json`
+3. `config.json`
+4. `config.example.json`
+
+If none of the earlier files exist, the app falls back to `config.example.json` and emits warnings.
+
+### Recommended local setup
+Use:
+- `config.local.json` for machine-specific settings
+- `.env` for environment variables and sensitive values
+
+---
+
+## 2. Path expansion and normalization
+
+The config loader in `lib/config.js` normalizes several values for you.
+
+### Supported path expansion
+- `~` expands to your home directory
+- `${HOME}` expands to your home directory
+
+### Normalization behavior
+The loader also:
+- deep-merges config with defaults
+- de-duplicates string lists such as repo lists and iCal URLs
+- derives some Obsidian paths from `obsidian.vaultDir` if they are omitted
+
+If `obsidian.vaultDir` is set but these are omitted, the loader derives:
+- `obsidian.dailyDir` → `03 - Periodic/01 - Daily`
+- `obsidian.decisionsDir` → `08 - Projects/DamageLabs/Decisions`
+
+---
+
+## 3. Example config
+
+A typical `config.local.json` looks like this:
+
+```json
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 4500
+  },
+  "github": {
+    "trackedRepos": [
+      "YourOrg/repo-one",
+      "YourOrg/repo-two",
+      "yourusername/personal-repo"
+    ],
+    "orgs": [
+      {
+        "owner": "YourOrg",
+        "repoLimit": 200
+      },
+      {
+        "owner": "yourusername",
+        "repoLimit": 100,
+        "includeRepos": [
+          "personal-repo"
+        ]
+      }
+    ]
+  },
+  "obsidian": {
+    "vaultDir": "/path/to/your/obsidian/vault",
+    "dailyDir": "/path/to/your/obsidian/vault/03 - Periodic/01 - Daily",
+    "decisionsDir": "/path/to/your/obsidian/vault/08 - Projects/DamageLabs/Decisions",
+    "tasksDir": "/path/to/your/tasks/folder",
+    "taskFiles": [
+      {
+        "file": "Tasks.md",
+        "label": "General",
+        "color": "amber"
+      },
+      {
+        "file": "Work Tasks.md",
+        "label": "Work",
+        "color": "blue"
+      }
+    ]
+  },
+  "standup": {
+    "dir": "${HOME}/Code/brain/standups/daily"
+  }
+}
+```
+
+---
+
+## 4. Server settings
+
+```json
+"server": {
+  "host": "127.0.0.1",
+  "port": 4500
+}
+```
+
+### `server.host`
+- default: `127.0.0.1`
+- controls where the Express backend binds
+
+Use a non-localhost host only if you intentionally want LAN exposure. This app is designed for trusted local use and does not include a built-in auth layer for dashboard access.
+
+### `server.port`
+- default: `4500`
+- controls the API port and the built-mode app port
+
+---
+
+## 5. GitHub settings
+
+```json
+"github": {
+  "trackedRepos": [...],
+  "orgs": [...]
+}
+```
+
+### `github.trackedRepos`
+Used for:
+- PR listing
+- targeted repo-level views
+
+Format:
+- `owner/repo`
+
+### `github.orgs`
+Used for repo discovery and issue scanning.
+
+Each entry supports:
+- `owner` (required)
+- `repoLimit` (optional, default `200`)
+- `includeRepos` (optional)
+- `excludeRepos` (optional)
+
+### If GitHub config is missing
+The app will still run, but GitHub-backed views will warn or remain empty.
+
+Also make sure:
+```bash
+gh auth status
+```
+works on the machine running the app.
+
+---
+
+## 6. Obsidian settings
+
+```json
+"obsidian": {
+  "vaultDir": "...",
+  "dailyDir": "...",
+  "decisionsDir": "...",
+  "tasksDir": "...",
+  "taskFiles": [...]
+}
+```
+
+### `vaultDir`
+Optional, but useful as a base path for derived defaults.
+
+### `dailyDir`
+Directory containing daily notes used by the Notes/Home surfaces.
+
+### `decisionsDir`
+Directory containing decision notes.
+
+### `tasksDir`
+Directory containing task markdown files.
+
+### `taskFiles`
+List of task files to parse.
+
+Each entry supports:
+- `file` (required)
+- `label` (optional, defaults to the file name)
+- `color` (optional, defaults to `amber`)
+
+Example:
+
+```json
+"taskFiles": [
+  {
+    "file": "Tasks.md",
+    "label": "General",
+    "color": "amber"
+  },
+  {
+    "file": "Work Tasks.md",
+    "label": "Work",
+    "color": "blue"
+  }
+]
+```
+
+### Task markdown expectations
+The parser expects standard markdown task lines, for example:
+
+```md
+- [ ] Ship dashboard polish #todo 📅 2026-04-20
+- [x] Merge PR ✅ 2026-04-14
+```
+
+---
+
+## 7. Standup settings
+
+```json
+"standup": {
+  "dir": "${HOME}/Code/brain/standups/daily"
+}
+```
+
+### `standup.dir`
+Directory containing daily standup markdown files.
+
+Expected naming pattern:
+- `YYYY-MM-DD.md`
+
+The standup parser expects repo sections and bullets, for example:
+
+```md
+## Yesterday
+### DamageLabs/command-center
+- PRs
+  - Finish Angular cutover
+- Issues
+  - Add API smoke coverage
+```
+
+---
+
+## 8. Calendar settings
+
+Calendar URLs are configured through environment variables rather than the main JSON config.
+
+### Supported env vars
+Use either:
+- `CALENDAR_URLS` as a comma-separated list
+
+or legacy variables:
+- `CAL_1`
+- `CAL_2`
+
+Example:
+
+```env
+CALENDAR_URLS=https://example.com/a.ics,https://example.com/b.ics
+```
+
+or:
+
+```env
+CAL_1=https://example.com/a.ics
+CAL_2=https://example.com/b.ics
+```
+
+The loader merges and de-duplicates these values.
+
+If no calendar URLs are provided, the calendar view is disabled and the app emits a startup warning.
+
+---
+
+## 9. Environment variables
+
+### `COMMAND_CENTER_CONFIG`
+Optional override for the config file path.
+
+Example:
+
+```env
+COMMAND_CENTER_CONFIG=./config.local.json
+```
+
+### Calendar vars
+- `CALENDAR_URLS`
+- `CAL_1`
+- `CAL_2`
+
+### Other optional env vars
+Some optional integrations may also use additional environment variables.
+
+Keep personal or machine-specific secrets local, preferably in `.env`, and out of committed docs and config files.
+
+---
+
+## 10. What happens when config is missing
+
+The config loader emits warnings when optional features are not configured.
+
+Common warning conditions include:
+- no `github.trackedRepos`
+- no `github.orgs`
+- missing `obsidian.tasksDir` or `obsidian.taskFiles`
+- missing `obsidian.dailyDir`
+- missing `obsidian.decisionsDir`
+- missing `standup.dir`
+- no calendar URLs
+
+This is intentional. The app is designed to degrade gracefully instead of refusing to start.
+
+---
+
+## 11. Recommended config hygiene
+
+- keep `config.local.json` uncommitted and machine-specific
+- keep secrets in `.env` instead of checked-in JSON
+- prefer `127.0.0.1` unless you intentionally want LAN access
+- use `${HOME}` or `~` for portable local paths
+- start from `config.example.json`, then trim or expand for your setup
+
+---
+
+## 12. Quick validation checklist
+
+After updating config, check:
+
+```bash
+npm run check
+npm test
+```
+
+Then verify the live app:
+
+```bash
+curl http://127.0.0.1:4500/api/issues
+curl http://127.0.0.1:4500/api/tasks
+curl http://127.0.0.1:4500/api/calendar
+curl http://127.0.0.1:4500/api/openclaw
+```
+
+If a panel is empty, confirm the corresponding local path, CLI auth, or environment variable is actually present and valid on the machine running the app.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,0 +1,224 @@
+# Installation
+
+This guide covers getting `command-center` running locally for development or daily use on a machine you control.
+
+For architecture, see [System-Design.md](./System-Design.md).
+For configuration details, see [Configuration.md](./Configuration.md).
+For the Linux durable local runner, see [local-runtime.md](./local-runtime.md).
+
+---
+
+## 1. What you are installing
+
+`command-center` is a local dashboard with:
+- a Node/Express API on port `4500`
+- an Angular frontend on port `4200` during development
+- optional local integrations for GitHub, calendar feeds, Obsidian content, standups, PM2, and analytics
+
+There are two main ways to run it:
+- **split dev mode**: Angular dev server + Express API
+- **built local mode**: Express serves the built Angular app
+
+On Linux, there is also a **durable local dev workflow** using user-level `systemd` services.
+
+---
+
+## 2. Prerequisites
+
+### Required
+- **Node.js 22+**
+- **npm**
+- **Git**
+
+### Required for GitHub-backed views
+- **GitHub CLI (`gh`)**
+- authenticated `gh` session via `gh auth login`
+
+### Optional
+- **PM2** if you want live PM2 data in the Infra view
+- **systemd --user** if you want the durable Linux runner
+- **Caddy** / local HTTPS tooling if you want a custom local hostname such as `https://command.test`
+
+---
+
+## 3. Clone and install dependencies
+
+```bash
+git clone git@github.com:DamageLabs/command-center.git
+cd command-center
+npm install
+npm --prefix frontend install
+```
+
+---
+
+## 4. Create local config files
+
+Copy the local env and config templates:
+
+```bash
+cp .env.example .env
+cp config.example.json config.local.json
+```
+
+`config.local.json` is the recommended place for machine-specific paths, repo lists, and other local-only settings.
+
+---
+
+## 5. Configure the app
+
+At minimum, edit:
+- `.env`
+- `config.local.json`
+
+### Typical minimum setup
+- configure GitHub repos and orgs in `config.local.json`
+- configure Obsidian paths if you want notes, tasks, and decisions
+- configure the standup directory if you use the standup panel
+- add iCal URLs in `.env` if you want calendar data
+
+See [Configuration.md](./Configuration.md) for the full config surface.
+
+---
+
+## 6. Run in development
+
+### Single command
+```bash
+npm run dev
+```
+
+This starts:
+- API on `:4500`
+- Angular dev server on `:4200`
+
+### Split mode
+```bash
+npm run dev:api
+npm run dev:web
+```
+
+In split mode:
+- the Angular dev server runs on `http://localhost:4200`
+- `/api/*` is proxied to the backend on `http://localhost:4500`
+
+---
+
+## 7. Run the durable local Linux workflow
+
+If you want the local dashboard to stay up persistently on a Linux workstation:
+
+```bash
+npm run dev:durable:start
+npm run dev:durable:status
+npm run dev:durable:logs -- -f
+```
+
+Other useful commands:
+
+```bash
+npm run dev:durable:restart
+npm run dev:durable:stop
+npm run dev:durable:uninstall
+```
+
+This installs user services for:
+- `command-center-api.service`
+- `command-center-web.service`
+
+For more detail, see [local-runtime.md](./local-runtime.md).
+
+---
+
+## 8. Run the built local mode
+
+Build the Angular app:
+
+```bash
+npm run build:web
+```
+
+Then start the backend:
+
+```bash
+npm start
+```
+
+In this mode, Express serves both:
+- the API
+- the built frontend from `frontend/dist/frontend/browser`
+
+---
+
+## 9. Verification
+
+### Quick checks
+
+Frontend dev server:
+```bash
+curl -I http://127.0.0.1:4200/
+```
+
+API:
+```bash
+curl -I http://127.0.0.1:4500/
+```
+
+OpenClaw route:
+```bash
+curl http://127.0.0.1:4500/api/openclaw
+```
+
+Build + syntax check:
+```bash
+npm run check
+```
+
+Server tests:
+```bash
+npm test
+```
+
+---
+
+## 10. Optional local HTTPS
+
+If you want a nicer local URL such as `https://command.test`, you can front the app with local HTTPS tooling such as Caddy.
+
+Typical shape:
+- resolve a local hostname to your workstation
+- reverse proxy that hostname to the app
+- trust the local development certificate authority
+
+This is optional and not required for normal local use.
+
+---
+
+## 11. Common setup notes
+
+### GitHub data looks empty
+Make sure:
+- `gh` is installed
+- `gh auth status` succeeds
+- your `github.trackedRepos` and `github.orgs` config is populated
+
+### Tasks, notes, or decisions are empty
+Make sure the Obsidian paths in `config.local.json` point to real directories on disk.
+
+### Calendar is empty
+Make sure you added valid iCal URLs in `.env` using `CALENDAR_URLS` or `CAL_1` / `CAL_2`.
+
+### Infra is degraded
+That often means PM2 is not installed or not available in the current environment. The rest of the app can still work.
+
+### Durable runner is unavailable
+The durable runner requires Linux with `systemd --user` available.
+
+---
+
+## 12. Recommended local workflow
+
+For day-to-day development:
+- use `npm run dev` for short interactive sessions
+- use `npm run dev:durable:start` on Linux when you want the dashboard to stay up continuously
+- keep personal paths and secrets in `config.local.json` and `.env`


### PR DESCRIPTION
## Summary
- add `docs/Installation.md` for local setup and runtime workflows
- add `docs/Configuration.md` for config resolution, JSON settings, env vars, and validation
- keep analytics/provider wording generic and clarify trusted-local-use expectations

## Testing
- not run (docs only)